### PR TITLE
feat: harden public API docs generation and auth guidance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,11 +20,13 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || (github.event_name == 'repository_dispatch' && github.event.client_payload.branch || github.ref_name) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || (github.event_name == 'repository_dispatch' && github.event.client_payload.branch || github.ref_name) }}
+          ref: ${{ env.DEPLOY_BRANCH }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -38,7 +40,7 @@ jobs:
       - name: Build documentation
         run: ./generate.sh
         env:
-          STAGING_DOCS: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch == 'dev') || (github.event_name != 'workflow_dispatch' && github.ref_name == 'dev')) && 'true' || 'false' }}
+          STAGING_DOCS: ${{ env.DEPLOY_BRANCH == 'dev' && 'true' || 'false' }}
 
       - name: Upload generated spec
         uses: actions/upload-artifact@v4
@@ -63,4 +65,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy html --project-name=${{ (github.event_name == 'workflow_dispatch' && inputs.branch == 'master' || (github.event_name != 'workflow_dispatch' && github.ref_name == 'master')) && secrets.CLOUDFLARE_PROJECT_NAME || secrets.CLOUDFLARE_PROJECT_NAME_DEV }} --branch=${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
+          command: pages deploy html --project-name=${{ env.DEPLOY_BRANCH == 'master' && secrets.CLOUDFLARE_PROJECT_NAME || secrets.CLOUDFLARE_PROJECT_NAME_DEV }} --branch=${{ env.DEPLOY_BRANCH }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,8 @@ on:
         required: true
         type: choice
         options:
-      - master
-      - dev
+          - master
+          - dev
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,11 @@ on:
         required: true
         type: choice
         options:
-          - master
-          - dev
+      - master
+      - dev
+
+permissions:
+  contents: read
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy Public Docs
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
       - dev
   repository_dispatch:
     types: [api-spec-updated]
-    
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to deploy'
+        description: Branch to deploy
         required: true
         type: choice
         options:
@@ -27,15 +26,41 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || (github.event_name == 'repository_dispatch' && github.event.client_payload.branch || github.ref_name) }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+          cache: npm
+
+      - name: Install toolchain
+        run: npm ci
+
       - name: Build documentation
-        run: docker compose up
+        run: ./generate.sh
         env:
           STAGING_DOCS: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch == 'dev') || (github.event_name != 'workflow_dispatch' && github.ref_name == 'dev')) && 'true' || 'false' }}
-      
+
+      - name: Upload generated spec
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-openapi-${{ github.sha }}
+          path: openapi-v3.0.yaml
+
+      - name: Upload validation reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-reports-${{ github.sha }}
+          path: artifacts/validation
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle-${{ github.sha }}
+          path: artifacts/release
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy html --project-name=${{ (github.event_name == 'workflow_dispatch' && inputs.branch == 'master' || (github.event_name != 'workflow_dispatch' && github.ref_name == 'master')) && secrets.CLOUDFLARE_PROJECT_NAME || secrets.CLOUDFLARE_PROJECT_NAME_DEV }} --branch=${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release Public Spec
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+          cache: npm
+
+      - name: Install toolchain
+        run: npm ci
+
+      - name: Generate release artifacts
+        run: ./generate.sh
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/release/openapi-v3.0.yaml
+            artifacts/release/html-docs.tar.gz
+          generate_release_notes: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,51 @@
+name: Validate Public Docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+          cache: npm
+
+      - name: Install toolchain
+        run: npm ci
+
+      - name: Generate and validate public docs
+        run: ./generate.sh
+
+      - name: Upload generated spec
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-openapi-${{ github.sha }}
+          path: openapi-v3.0.yaml
+
+      - name: Upload HTML docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-docs-${{ github.sha }}
+          path: html
+
+      - name: Upload validation reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-reports-${{ github.sha }}
+          path: artifacts/validation
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle-${{ github.sha }}
+          path: artifacts/release

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
       - master
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ spec/storage*
 spec/icas*
 spec/ai*
 spec/authentication*
-spec/*bundeled.yaml
+spec/*bundled.*
 openapi-v*
 html/*
+artifacts/*
+node_modules/
 .idea
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:20
+FROM node:20.19.0
 
-RUN npm install -g npm@latest && \ 
-    npm install -g openapi-merge-cli && \ 
-    npm install -g @redocly/cli@1.0.0-beta.129
+WORKDIR /tooling
+
+COPY package.json package-lock.json ./
+
+RUN npm ci --omit=dev

--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # Formaloo API Documentation
 
-Repository for generating Formaloo API documentation from OpenAPI specifications across multiple services.
+Repository for generating the public Formaloo API reference from OpenAPI specifications across multiple services.
 
 ## Running the Service
 
-Build and generate documentation:
+Install the pinned tooling:
 
 ```bash
-docker compose up
+npm ci
 ```
 
-The generated HTML files are available in the `html` directory. Serve them locally:
+Generate the public spec, validation reports, and HTML docs:
+
+```bash
+./generate.sh
+```
+
+You can still run the full build in Docker:
+
+```bash
+docker compose up --build
+```
+
+Generated outputs:
+
+- `openapi-v3.0.yaml`: canonical public OpenAPI artifact
+- `html/`: generated static docs bundle
+- `artifacts/validation/`: validation and lint reports
+- `artifacts/release/`: packaged release assets
+
+Optional generation metadata:
+
+- `spec/operation-metadata.json`: optional sidecar manifest for public-safe operation metadata. The pipeline succeeds when this file is absent.
+
+Serve the generated docs locally:
 
 ```bash
 cd html && python3 -m http.server 8000
@@ -21,7 +44,7 @@ cd html && python3 -m http.server 8000
 Use `STAGING_DOCS=true` to generate documentation from staging endpoints:
 
 ```bash
-STAGING_DOCS=true docker compose up
+STAGING_DOCS=true ./generate.sh
 ```
 
 - **Production** (default): Uses `api.formaloo.me` and related production endpoints
@@ -29,17 +52,17 @@ STAGING_DOCS=true docker compose up
 
 ## Contributing
 
-Documentation consists of automated OpenAPI specs from services and manual descriptions added in this repository.
+Documentation consists of automated OpenAPI specs from services, a public normalization step, and manual descriptions added in this repository.
 
 ### Adding Manual Descriptions
 
-Manual descriptions are stored as Markdown files matching the endpoint path and HTTP method. For example, the endpoint `PATCH /v2.0/forms/{slug}/` uses:
+Manual descriptions are stored as Markdown files matching the endpoint path and HTTP method. For example, the endpoint `PATCH /v3.0/forms/{slug}/` uses:
 
-- `spec/docs/v2.0/forms/{slug}/patch.md`
-- `spec/docs/v2.0/forms/{slug}/put.md` (if PUT is also supported)
+- `spec/docs/v3.0/forms/{slug}/patch.md`
+- `spec/docs/v3.0/forms/{slug}/put.md` (if PUT is also supported)
 
-Run `docker compose up` to automatically create missing documentation file structure, then edit the generated files.
+Run `./generate.sh` to prepare missing documentation file structure during generation, then add or update the relevant markdown files in `spec/docs/`.
 
 ### Version Introductions
 
-Each API version has an introduction file (e.g., `spec/docs/v2.0/intro.md`) containing version overview, getting started guide, and general considerations.
+The public reference uses `spec/docs/v3.0/intro.md` for onboarding and version guidance.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ Manual descriptions are stored as Markdown files matching the endpoint path and 
 - `spec/docs/v3.0/forms/{slug}/patch.md`
 - `spec/docs/v3.0/forms/{slug}/put.md` (if PUT is also supported)
 
-Run `./generate.sh` to prepare missing documentation file structure during generation, then add or update the relevant markdown files in `spec/docs/`.
+To create local placeholder markdown files for missing endpoint docs, run:
+
+```bash
+npm run prepare-doc-stubs
+```
+
+`./generate.sh` also prepares these paths during the build, but it removes temporary stubs before exiting so the worktree stays clean.
 
 ### Version Introductions
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Generated outputs:
 Optional generation metadata:
 
 - `spec/operation-metadata.json`: optional sidecar manifest for public-safe operation metadata. The pipeline succeeds when this file is absent.
+- `spec/tag-metadata.json`: public-facing tag naming and description overrides for generated docs navigation.
 
 Serve the generated docs locally:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: "3.8"
-
 services:
   app:
     container_name: spec
     build:
       dockerfile: Dockerfile
       context: .
-    command: bash -c "bash ./files/generate.sh"
+    command: bash -lc "cd /files && ./generate.sh"
     volumes:
       - .:/files
     environment:

--- a/generate.sh
+++ b/generate.sh
@@ -1,64 +1,112 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cd /files/spec/
+set -euo pipefail
 
-# Default to production (STAGING_DOCS=false)
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+SPEC_DIR="$ROOT_DIR/spec"
+HTML_DIR="$ROOT_DIR/html"
+ARTIFACTS_DIR="$ROOT_DIR/artifacts"
+INTERMEDIATE_DIR="$ARTIFACTS_DIR/intermediate"
+VALIDATION_DIR="$ARTIFACTS_DIR/validation"
+RELEASE_DIR="$ARTIFACTS_DIR/release"
+DOC_STUB_MANIFEST="$INTERMEDIATE_DIR/generated-doc-stubs.txt"
+
 STAGING_DOCS=${STAGING_DOCS:-false}
+PUBLIC_API_URL=${PUBLIC_API_URL:-}
 
-if [ "$STAGING_DOCS" = "true" ]; then
-    echo "Using STAGING endpoints..."
-    BASE_DOMAIN="staging.formaloo.com"
-    wget -O icas.yaml https://id.staging.formaloo.com/docs/openapi/yaml/?version=3.0
-    wget -O formz.yaml https://api.staging.formaloo.com/docs/openapi/yaml/?version=3.0
-    wget -O authentication.yaml https://auth.staging.formaloo.com/docs/openapi/yaml?version=3.0
-    wget -O storage.yaml https://storage.staging.formaloo.com/docs/openapi/yaml/?version=3.0
-    wget -O ai.yaml https://ai.staging.formaloo.com/docs/openapi/yaml/?version=3.0
+if [[ -n "${TOOLS_DIR:-}" ]]; then
+  TOOL_BIN="$TOOLS_DIR"
+elif [[ -d "/tooling/node_modules/.bin" ]]; then
+  TOOL_BIN="/tooling/node_modules/.bin"
 else
-    echo "Using PRODUCTION endpoints..."
-    BASE_DOMAIN="formaloo.me"
-    wget -O icas.yaml https://id.formaloo.com/docs/openapi/yaml/?version=3.0
-    wget -O formz.yaml https://api.formaloo.me/docs/openapi/yaml/?version=3.0
-    wget -O authentication.yaml https://auth.formaloo.me/docs/openapi/yaml?version=3.0
-    wget -O storage.yaml https://storage.formaloo.me/docs/openapi/yaml/?version=3.0
-    wget -O ai.yaml https://ai-api.formaloo.co/docs/openapi/yaml/?version=3.0
+  TOOL_BIN="$ROOT_DIR/node_modules/.bin"
 fi
 
-files=( icas.yaml formz.yaml authentication.yaml storage.yaml ai.yaml )
-for file in "${files[@]}"; 
-do
-    if [ -f "$file" ] && [ -s "$file" ]; then
-        grep -o 'docs.*.md' $file | while read -r line ; 
-        do
-            mkdir -p "${line%/*}" && touch "$line"
-        done
-    else
-        echo "Warning: $file is missing or empty, skipping..."
+REDOCLY_BIN="$TOOL_BIN/redocly"
+OPENAPI_MERGE_BIN="$TOOL_BIN/openapi-merge-cli"
+
+if [[ ! -x "$REDOCLY_BIN" || ! -x "$OPENAPI_MERGE_BIN" ]]; then
+  echo "Missing required tooling. Run 'npm ci' or build through Docker first." >&2
+  exit 1
+fi
+
+mkdir -p "$HTML_DIR" "$INTERMEDIATE_DIR" "$VALIDATION_DIR" "$RELEASE_DIR"
+rm -rf "$HTML_DIR"/* "$INTERMEDIATE_DIR"/* "$VALIDATION_DIR"/* "$RELEASE_DIR"/*
+
+cleanup_generated_doc_stubs() {
+  if [[ ! -f "$DOC_STUB_MANIFEST" ]]; then
+    return
+  fi
+
+  while IFS= read -r file_path; do
+    [[ -n "$file_path" ]] || continue
+
+    if [[ -f "$file_path" ]]; then
+      rm -f "$file_path"
     fi
-done
 
-[ -f "icas.yaml" ] && [ -s "icas.yaml" ] && redocly bundle icas.yaml -o icas-bundeled.yaml || echo "Skipping icas.yaml bundling"
-[ -f "formz.yaml" ] && [ -s "formz.yaml" ] && redocly bundle formz.yaml -o formz-bundeled.yaml || echo "Skipping formz.yaml bundling"
-[ -f "authentication.yaml" ] && [ -s "authentication.yaml" ] && redocly bundle authentication.yaml -o authentication-bundeled.yaml || echo "Skipping authentication.yaml bundling"
-[ -f "storage.yaml" ] && [ -s "storage.yaml" ] && redocly bundle storage.yaml -o storage-bundeled.yaml || echo "Skipping storage.yaml bundling"
-[ -f "ai.yaml" ] && [ -s "ai.yaml" ] && redocly bundle ai.yaml -o ai-bundeled.yaml || echo "Skipping ai.yaml bundling"
-[ -f "v3.0.yaml" ] && [ -s "v3.0.yaml" ] && redocly bundle v3.0.yaml -o v3.0-bundeled.yaml || echo "Skipping v3.0.yaml bundling"
+    dir_path=$(dirname "$file_path")
+    while [[ "$dir_path" == "$SPEC_DIR"* && "$dir_path" != "$SPEC_DIR" ]]; do
+      rmdir "$dir_path" 2>/dev/null || break
+      dir_path=$(dirname "$dir_path")
+    done
+  done < "$DOC_STUB_MANIFEST"
+}
 
-npx openapi-merge-cli --config openapi-merge-v3.0.json
-rm -f formz* icas* authentication* ai* storage-bundeled.yaml v3.0-bundeled.yaml 
+trap cleanup_generated_doc_stubs EXIT
 
-cd /files
+echo "Fetching upstream specifications..."
+node "$ROOT_DIR/scripts/fetch-specs.mjs"
+node "$ROOT_DIR/scripts/prepare-doc-stubs.mjs"
 
-# Update server URL in merged openapi-v3.0.yaml based on environment
-if [ "$STAGING_DOCS" = "true" ]; then
-    echo "Setting server URL to STAGING..."
-    sed -i "s|url: 'https://api\.[^']*'|url: 'https://api.staging.formaloo.com'|g" openapi-v3.0.yaml
-    sed -i 's|description: Formaloo Server|description: Formaloo Staging Server|g' openapi-v3.0.yaml
-else
-    echo "Setting server URL to PRODUCTION..."
-    sed -i "s|url: 'https://api\.[^']*'|url: 'https://api.formaloo.me'|g" openapi-v3.0.yaml
+bundle_spec() {
+  local input_file="$1"
+  local output_file="$2"
+
+  if [[ -s "$input_file" ]]; then
+    "$REDOCLY_BIN" bundle "$input_file" --output "$output_file"
+  else
+    echo "Skipping missing spec: $input_file"
+  fi
+}
+
+echo "Bundling service specifications..."
+bundle_spec "$SPEC_DIR/icas.yaml" "$SPEC_DIR/icas-bundled.json"
+bundle_spec "$SPEC_DIR/formz.yaml" "$SPEC_DIR/formz-bundled.json"
+bundle_spec "$SPEC_DIR/authentication.yaml" "$SPEC_DIR/authentication-bundled.json"
+bundle_spec "$SPEC_DIR/storage.yaml" "$SPEC_DIR/storage-bundled.json"
+bundle_spec "$SPEC_DIR/ai.yaml" "$SPEC_DIR/ai-bundled.json"
+bundle_spec "$SPEC_DIR/v3.0.yaml" "$SPEC_DIR/v3.0-bundled.json"
+
+echo "Merging public specification shell..."
+"$OPENAPI_MERGE_BIN" --config "$SPEC_DIR/openapi-merge-v3.0.json"
+
+echo "Normalizing public contract..."
+if [[ -z "$PUBLIC_API_URL" ]]; then
+  if [[ "$STAGING_DOCS" == "true" ]]; then
+    PUBLIC_API_URL="https://api.staging.formaloo.com"
+  else
+    PUBLIC_API_URL="https://api.formaloo.me"
+  fi
+fi
+PUBLIC_API_URL="$PUBLIC_API_URL" STAGING_DOCS="$STAGING_DOCS" node "$ROOT_DIR/scripts/normalize-openapi.mjs"
+
+echo "Rendering final YAML artifact..."
+"$REDOCLY_BIN" bundle "$INTERMEDIATE_DIR/openapi-public.normalized.json" --output "$ROOT_DIR/openapi-v3.0.yaml"
+
+echo "Validating generated public contract..."
+node "$ROOT_DIR/scripts/validate-openapi.mjs"
+if ! "$REDOCLY_BIN" lint "$ROOT_DIR/openapi-v3.0.yaml" > "$VALIDATION_DIR/redocly-lint.txt" 2>&1; then
+  echo "Redocly lint reported issues. Report saved to artifacts/validation/redocly-lint.txt"
 fi
 
-mkdir -p /files/html/ && rm -rf /files/html/*
-redocly build-docs openapi-v3.0.yaml -o html/index.html
-cp /files/openapi*.yaml /files/html/
-cp -r /files/assets /files/html/
+echo "Building HTML documentation..."
+"$REDOCLY_BIN" build-docs "$ROOT_DIR/openapi-v3.0.yaml" -o "$HTML_DIR/index.html"
+cp "$ROOT_DIR/openapi-v3.0.yaml" "$HTML_DIR/openapi-v3.0.yaml"
+cp -r "$ROOT_DIR/assets" "$HTML_DIR/"
+
+echo "Packaging release artifacts..."
+cp "$ROOT_DIR/openapi-v3.0.yaml" "$RELEASE_DIR/openapi-v3.0.yaml"
+tar -czf "$RELEASE_DIR/html-docs.tar.gz" -C "$ROOT_DIR" html
+
+echo "Build complete."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2802 @@
+{
+  "name": "formaloo-api-documentations",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "formaloo-api-documentations",
+      "dependencies": {
+        "@redocly/cli": "1.34.5",
+        "openapi-merge-cli": "1.3.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw=="
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ]
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.5.tgz",
+      "integrity": "sha512-5IEwxs7SGP5KEXjBKLU8Ffdz9by/KqNSeBk6YUVQaGxMXK//uYlTJIPntgUXbo1KAGG2d2q2XF8y4iFz6qNeiw==",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@redocly/config": "^0.22.0",
+        "@redocly/openapi-core": "1.34.5",
+        "@redocly/respect-core": "1.34.5",
+        "abort-controller": "^3.0.0",
+        "chokidar": "^3.5.1",
+        "colorette": "^1.2.0",
+        "core-js": "^3.32.1",
+        "dotenv": "16.4.7",
+        "form-data": "^4.0.4",
+        "get-port-please": "^3.0.1",
+        "glob": "^7.1.6",
+        "handlebars": "^4.7.6",
+        "mobx": "^6.0.4",
+        "pluralize": "^8.0.0",
+        "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.2.0 || ^19.0.0",
+        "redoc": "2.5.0",
+        "semver": "^7.5.2",
+        "simple-websocket": "^9.0.0",
+        "styled-components": "^6.0.7",
+        "yargs": "17.0.1"
+      },
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz",
+      "integrity": "sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ=="
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.5.tgz",
+      "integrity": "sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA==",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.2",
+        "@redocly/config": "^0.22.0",
+        "colorette": "^1.2.0",
+        "https-proxy-agent": "^7.0.5",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^5.0.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.5.tgz",
+      "integrity": "sha512-GheC/g/QFztPe9UA9LamooSplQuy9pe0Yr8XGTqkz0ahivLDl7svoy/LSQNn1QH3XGtLKwFYMfTwFR2TAYyh5Q==",
+      "dependencies": {
+        "@faker-js/faker": "^7.6.0",
+        "@redocly/ajv": "8.11.2",
+        "@redocly/openapi-core": "1.34.5",
+        "better-ajv-errors": "^1.2.0",
+        "colorette": "^2.0.20",
+        "concat-stream": "^2.0.0",
+        "cookie": "^0.7.2",
+        "dotenv": "16.4.7",
+        "form-data": "^4.0.4",
+        "jest-diff": "^29.3.1",
+        "jest-matcher-utils": "^29.3.1",
+        "js-yaml": "4.1.0",
+        "json-pointer": "^0.6.2",
+        "jsonpath-plus": "^10.0.6",
+        "open": "^10.1.0",
+        "openapi-sampler": "^1.6.1",
+        "outdent": "^0.8.0",
+        "set-cookie-parser": "^2.3.5",
+        "undici": "^6.21.1"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+    },
+    "node_modules/@redocly/respect-core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/atlassian-openapi": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/atlassian-openapi/-/atlassian-openapi-1.0.21.tgz",
+      "integrity": "sha512-1OnnoY2CQYHgXrce/06BltL7fox+uVY7brHUInyFbMpTURjTNIGXfLQxVDRo/2On7ryyKzkX7FfNApYhXw7f+w==",
+      "deprecated": "DEPRECATED: atlassian-openapi has moved to @atlassian/atlassian-openapi. The latest version is 1.0.6. Please update your dependency.",
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "urijs": "^1.19.10"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/better-ajv-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
+      "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
+        "chalk": "^4.1.2",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ=="
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA=="
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mobx": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
+      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.1.tgz",
+      "integrity": "sha512-WJNNm0FB2n0Z0u+jS1QHmmWyV8l2WiAj8V8I/96kbUEN2YbYCoKW+hbbqKKRUBqElu0llxM7nWKehvRIkhBVJw==",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
+    "node_modules/node-readfiles/node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-merge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/openapi-merge/-/openapi-merge-1.3.3.tgz",
+      "integrity": "sha512-zC6DE+ekFJwWMwssb+LOkZbYqlA/LCaFT4RdhSpDpxF4vaMoPNDuztWFkEAImhLMg4GKvoQH6gUvAKzaXDRC2A==",
+      "dependencies": {
+        "atlassian-openapi": "^1.0.8",
+        "lodash": "^4.17.15",
+        "ts-is-present": "^1.1.1"
+      }
+    },
+    "node_modules/openapi-merge-cli": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/openapi-merge-cli/-/openapi-merge-cli-1.3.2.tgz",
+      "integrity": "sha512-f2F5SRwZpcxvEpMm776Lh2XW9XqNuRedMzlCA0usx9JgQmZUhtC24px4zFYc5J/ZYXvNG6mdqdj/D0BnfEy6AA==",
+      "dependencies": {
+        "ajv": "^6.12.2",
+        "commander": "^5.1.0",
+        "es6-promise": "^4.2.8",
+        "isomorphic-fetch": "^3",
+        "js-yaml": "^3.14.0",
+        "openapi-merge": "^1.2.0"
+      },
+      "bin": {
+        "openapi-merge-cli": "dist/cli.js"
+      }
+    },
+    "node_modules/openapi-merge-cli/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/openapi-merge-cli/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/openapi-merge-cli/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/openapi-merge-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.2.tgz",
+      "integrity": "sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^5.5.1",
+        "json-pointer": "0.6.2"
+      }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+      "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw=="
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-tabs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.1.tgz",
+      "integrity": "sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redoc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.0.tgz",
+      "integrity": "sha512-NpYsOZ1PD9qFdjbLVBZJWptqE+4Y6TkUuvEOqPUmoH7AKOmPcE+hYjotLxQNTqVoWL4z0T2uxILmcc8JGDci+Q==",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.4.0",
+        "classnames": "^2.3.2",
+        "decko": "^1.2.0",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.1",
+        "json-pointer": "^0.6.2",
+        "lunr": "^2.3.9",
+        "mark.js": "^8.11.1",
+        "marked": "^4.3.0",
+        "mobx-react": "^9.1.1",
+        "openapi-sampler": "^1.5.0",
+        "path-browserify": "^1.0.1",
+        "perfect-scrollbar": "^1.5.5",
+        "polished": "^4.2.2",
+        "prismjs": "^1.29.0",
+        "prop-types": "^15.8.1",
+        "react-tabs": "^6.0.2",
+        "slugify": "~1.4.7",
+        "stickyfill": "^1.1.1",
+        "swagger2openapi": "^7.0.8",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=6.9",
+        "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.1.4",
+        "mobx": "^6.0.4",
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
+    },
+    "node_modules/simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
+    },
+    "node_modules/styled-components": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.0.tgz",
+      "integrity": "sha512-BL1EDFpt+q10eAeZB0q9ps6pSlPejaBQWBkiuM16pyoVTG4NhZrPrZK0cqNbrozxSsYwUsJ9SQYN6NyeKJYX9A==",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-is-present": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-is-present/-/ts-is-present-1.2.2.tgz",
+      "integrity": "sha512-cA5MPLWGWYXvnlJb4TamUUx858HVHBsxxdy8l7jxODOLDyGYnQOllob2A2jyDghGa5iJHs2gzFNHvwGJ0ZfR8g=="
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "formaloo-api-documentations",
+  "private": true,
+  "scripts": {
+    "build:docs": "./generate.sh",
+    "fetch-specs": "node ./scripts/fetch-specs.mjs",
+    "prepare-doc-stubs": "node ./scripts/prepare-doc-stubs.mjs",
+    "normalize-spec": "node ./scripts/normalize-openapi.mjs",
+    "validate-spec": "node ./scripts/validate-openapi.mjs"
+  },
+  "dependencies": {
+    "@redocly/cli": "1.34.5",
+    "openapi-merge-cli": "1.3.2"
+  }
+}

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,8 @@
+extends:
+  - recommended
+
+rules:
+  info-license: off
+  no-path-trailing-slash: off
+  security-defined: off
+  tag-description: off

--- a/scripts/fetch-specs.mjs
+++ b/scripts/fetch-specs.mjs
@@ -24,32 +24,40 @@ const sources = staging
 
 await fs.mkdir(specDir, { recursive: true });
 
+function fetchSpec(outputPath, url) {
+  const commonArgs = [
+    "--fail",
+    "--location",
+    "--silent",
+    "--show-error",
+    "--retry",
+    "4",
+    "--retry-delay",
+    "2",
+    "--connect-timeout",
+    "15",
+    "--max-time",
+    "90",
+    "--output",
+    outputPath,
+    url
+  ];
+
+  try {
+    execFileSync("curl", commonArgs, { stdio: "inherit" });
+    return;
+  } catch (error) {
+    if (error.status !== 16) {
+      throw error;
+    }
+  }
+
+  execFileSync("curl", ["--http1.1", ...commonArgs], { stdio: "inherit" });
+}
+
 for (const [name, url] of Object.entries(sources)) {
   const outputPath = path.join(specDir, `${name}.yaml`);
-
-  execFileSync(
-    "curl",
-    [
-      "--fail",
-      "--location",
-      "--silent",
-      "--show-error",
-      "--retry",
-      "4",
-      "--retry-delay",
-      "2",
-      "--connect-timeout",
-      "15",
-      "--max-time",
-      "90",
-      "--output",
-      outputPath,
-      url
-    ],
-    {
-      stdio: "inherit"
-    }
-  );
+  fetchSpec(outputPath, url);
 
   console.log(`Fetched ${name} spec -> ${path.relative(rootDir, outputPath)}`);
 }

--- a/scripts/fetch-specs.mjs
+++ b/scripts/fetch-specs.mjs
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const specDir = path.join(rootDir, "spec");
+const staging = process.env.STAGING_DOCS === "true";
+
+const sources = staging
+  ? {
+      icas: "https://id.staging.formaloo.com/docs/openapi/yaml/?version=3.0",
+      formz: "https://api.staging.formaloo.com/docs/openapi/yaml/?version=3.0",
+      authentication: "https://auth.staging.formaloo.com/docs/openapi/yaml?version=3.0",
+      storage: "https://storage.staging.formaloo.com/docs/openapi/yaml/?version=3.0",
+      ai: "https://ai.staging.formaloo.com/docs/openapi/yaml/?version=3.0"
+    }
+  : {
+      icas: "https://id.formaloo.com/docs/openapi/yaml/?version=3.0",
+      formz: "https://api.formaloo.me/docs/openapi/yaml/?version=3.0",
+      authentication: "https://auth.formaloo.me/docs/openapi/yaml?version=3.0",
+      storage: "https://storage.formaloo.me/docs/openapi/yaml/?version=3.0",
+      ai: "https://ai-api.formaloo.co/docs/openapi/yaml/?version=3.0"
+    };
+
+await fs.mkdir(specDir, { recursive: true });
+
+for (const [name, url] of Object.entries(sources)) {
+  const outputPath = path.join(specDir, `${name}.yaml`);
+
+  execFileSync(
+    "curl",
+    [
+      "--fail",
+      "--location",
+      "--silent",
+      "--show-error",
+      "--retry",
+      "4",
+      "--retry-delay",
+      "2",
+      "--connect-timeout",
+      "15",
+      "--max-time",
+      "90",
+      "--output",
+      outputPath,
+      url
+    ],
+    {
+      stdio: "inherit"
+    }
+  );
+
+  console.log(`Fetched ${name} spec -> ${path.relative(rootDir, outputPath)}`);
+}

--- a/scripts/fetch-specs.mjs
+++ b/scripts/fetch-specs.mjs
@@ -32,6 +32,7 @@ function fetchSpec(outputPath, url) {
     "--show-error",
     "--retry",
     "4",
+    "--retry-all-errors",
     "--retry-delay",
     "2",
     "--connect-timeout",
@@ -43,11 +44,18 @@ function fetchSpec(outputPath, url) {
     url
   ];
 
+  const http1FallbackExitCodes = new Set([
+    16, // HTTP/2 framing layer error
+    52, // empty reply from server
+    56, // failure receiving network data
+    92 // HTTP/2 stream error
+  ]);
+
   try {
     execFileSync("curl", commonArgs, { stdio: "inherit" });
     return;
   } catch (error) {
-    if (error.status !== 16) {
+    if (!http1FallbackExitCodes.has(error.status)) {
       throw error;
     }
   }

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -12,6 +12,10 @@ const tagMetadataPath = path.join(rootDir, "spec", "tag-metadata.json");
 const apiKeyHeaderDescription = "Your API Key from the Formaloo dashboard.";
 const workspaceHeaderDescription =
   "Current workspace identifier for workspace-scoped requests. Send this header when the endpoint requires a workspace context and your API key does not already identify the workspace.";
+const appIdHeaderDescription =
+  "Optional client portal or public app identifier. Use this header when the app explicitly provides an app identifier for portal-specific form submission.";
+const scopeHeaderDescription =
+  "Optional client portal scope identifier. Use this header on client portal authentication requests when your app relies on a specific scope.";
 const clientCredentialsAuthorizationDescription =
   "Use `Basic {API Secret}`. The API Secret shown in the Formaloo dashboard can be used directly here.";
 const endUserSessionAuthorizationDescription =
@@ -223,6 +227,36 @@ function normalizeHeaderParameters(pathKey, method, operation) {
       required: true,
       schema: { type: "string" },
       description: endUserSessionAuthorizationDescription
+    });
+  }
+
+  if (pathKey === "/v3.0/form-displays/slug/{slug}/submit/" && method === "post") {
+    upsertHeaderParameter(operation, {
+      in: "header",
+      name: "x-app-id",
+      required: false,
+      schema: { type: "string" },
+      description: appIdHeaderDescription
+    });
+  }
+
+  if (pathKey === "/v3.0/end-users/request-redirect/" && method === "post") {
+    upsertHeaderParameter(operation, {
+      in: "header",
+      name: "x-scope",
+      required: false,
+      schema: { type: "string" },
+      description: scopeHeaderDescription
+    });
+  }
+
+  if (pathKey === "/v3.0/end-users/profile/" && method === "get") {
+    upsertHeaderParameter(operation, {
+      in: "header",
+      name: "x-scope",
+      required: false,
+      schema: { type: "string" },
+      description: scopeHeaderDescription
     });
   }
 }

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -8,6 +8,7 @@ const rawSpecPath = path.join(intermediateDir, "openapi-merged.raw.json");
 const normalizedSpecPath = path.join(intermediateDir, "openapi-public.normalized.json");
 const publicContractPath = path.join(rootDir, "spec", "public-contract.json");
 const metadataPath = path.join(rootDir, "spec", "operation-metadata.json");
+const tagMetadataPath = path.join(rootDir, "spec", "tag-metadata.json");
 
 const publicContract = JSON.parse(await fs.readFile(publicContractPath, "utf8"));
 const spec = JSON.parse(await fs.readFile(rawSpecPath, "utf8"));
@@ -17,6 +18,13 @@ try {
   metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
 } catch {
   metadata = null;
+}
+
+let tagMetadata = {};
+try {
+  tagMetadata = JSON.parse(await fs.readFile(tagMetadataPath, "utf8"));
+} catch {
+  tagMetadata = {};
 }
 
 const defaultServerUrl =
@@ -41,6 +49,7 @@ spec.servers = [
 
 spec.components = spec.components ?? {};
 spec.components.securitySchemes = spec.components.securitySchemes ?? {};
+spec.components.responses = spec.components.responses ?? {};
 if (!spec.components.securitySchemes.ApiKeyAuthentication) {
   spec.components.securitySchemes.ApiKeyAuthentication = {
     type: "apiKey",
@@ -57,6 +66,15 @@ if (!spec.components.securitySchemes.JwtAuthentication) {
     description: 'Token-based authentication with required prefix "JWT"'
   };
 }
+spec.components.responses.BadRequest = spec.components.responses.BadRequest ?? {
+  description: "The request could not be processed. Review request parameters, headers, and payload values."
+};
+spec.components.responses.Unauthorized = spec.components.responses.Unauthorized ?? {
+  description: "Authentication credentials are missing, invalid, or expired."
+};
+spec.components.responses.NotFound = spec.components.responses.NotFound ?? {
+  description: "The requested resource could not be found."
+};
 
 const operationMetadata = metadata?.operations ?? {};
 const allowedMetadataKeys = new Set([
@@ -67,9 +85,83 @@ const allowedMetadataKeys = new Set([
   "statefulness"
 ]);
 const legacySessionSecuritySchemes = new Set(["cookieAuth", "basicAuth"]);
-const tagNames = new Set();
+const tagDefinitions = new Map();
 const sortedPaths = {};
 const httpMethods = new Set(["get", "post", "put", "patch", "delete", "options", "head", "trace"]);
+
+function titleizeTag(slug) {
+  const overrides = {
+    oauth2: "OAuth 2.0",
+    oembed: "oEmbed"
+  };
+
+  if (overrides[slug]) {
+    return overrides[slug];
+  }
+
+  return slug
+    .replace(/[_-]+/g, " ")
+    .replace(/\bapi\b/gi, "API")
+    .replace(/\bai\b/gi, "AI")
+    .replace(/\bnps\b/gi, "NPS")
+    .replace(/\bgsheet\b/gi, "GSheet")
+    .replace(/\bpdf\b/gi, "PDF")
+    .replace(/\boauth\b/gi, "OAuth")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function getTagDefinition(slug) {
+  const tagInfo = tagMetadata[slug] ?? {};
+  const displayName = tagInfo.displayName ?? titleizeTag(slug);
+
+  return {
+    name: displayName,
+    description: tagInfo.description ?? `Operations for ${displayName.toLowerCase()}.`,
+    "x-formaloo-tag-slug": slug
+  };
+}
+
+function hasHeaderParameter(operation, headerName) {
+  return (operation.parameters ?? []).some(
+    (parameter) =>
+      parameter?.in === "header" &&
+      typeof parameter?.name === "string" &&
+      parameter.name.toLowerCase() === headerName.toLowerCase()
+  );
+}
+
+function ensureResponse(operation, statusCode, refName) {
+  operation.responses = operation.responses ?? {};
+  if (!operation.responses[statusCode]) {
+    operation.responses[statusCode] = {
+      $ref: `#/components/responses/${refName}`
+    };
+  }
+}
+
+function ensureResponseDescriptions(operation, method) {
+  const defaults = {
+    "200": "Successful response.",
+    "201": "Resource created successfully.",
+    "202": "Request accepted successfully.",
+    "204": "No response body."
+  };
+
+  for (const [statusCode, response] of Object.entries(operation.responses ?? {})) {
+    if (!response || "$ref" in response) {
+      continue;
+    }
+
+    const description = typeof response.description === "string" ? response.description.trim() : "";
+    if (description) {
+      continue;
+    }
+
+    response.description =
+      defaults[statusCode] ??
+      (method === "delete" ? "Request completed successfully." : "Successful response.");
+  }
+}
 
 function getRefTarget(ref) {
   if (typeof ref !== "string" || !ref.startsWith("#/")) {
@@ -182,6 +274,27 @@ function normalizeSecurity(operation) {
   return operation;
 }
 
+function normalizeResponses(pathKey, method, operation) {
+  const responseCodes = Object.keys(operation.responses ?? {});
+  const has4xxResponse = responseCodes.some((statusCode) => /^4\d\d$/.test(statusCode));
+  const requiresAuth = Array.isArray(operation.security) && operation.security.length > 0;
+  const hasApiKeyHeader = hasHeaderParameter(operation, "x-api-key");
+
+  if (!has4xxResponse) {
+    ensureResponse(operation, "400", "BadRequest");
+  }
+
+  if ((requiresAuth || hasApiKeyHeader) && !operation.responses?.["401"]) {
+    ensureResponse(operation, "401", "Unauthorized");
+  }
+
+  if (pathKey.includes("{") && ["get", "put", "patch", "delete"].includes(method) && !operation.responses?.["404"]) {
+    ensureResponse(operation, "404", "NotFound");
+  }
+
+  ensureResponseDescriptions(operation, method);
+}
+
 function normalizeSchemaTree(node) {
   if (!node || typeof node !== "object") {
     return;
@@ -218,15 +331,21 @@ for (const pathKey of Object.keys(spec.paths).sort()) {
 
     const normalizedOperation = { ...operation };
     normalizeSecurity(normalizedOperation);
+    normalizeResponses(pathKey, method, normalizedOperation);
 
-    if (!Array.isArray(normalizedOperation.tags) || normalizedOperation.tags.length === 0) {
-      const firstSegment = pathKey.split("/").filter(Boolean)[1] ?? "general";
-      normalizedOperation.tags = [firstSegment];
-    }
-
-    for (const tag of normalizedOperation.tags) {
-      tagNames.add(tag);
-    }
+    const rawTags =
+      Array.isArray(normalizedOperation.tags) && normalizedOperation.tags.length > 0
+        ? normalizedOperation.tags
+        : [pathKey.split("/").filter(Boolean)[1] ?? "general"];
+    normalizedOperation.tags = Array.from(
+      new Set(
+        rawTags.map((tagSlug) => {
+          const tagDefinition = getTagDefinition(tagSlug);
+          tagDefinitions.set(tagDefinition.name, tagDefinition);
+          return tagDefinition.name;
+        })
+      )
+    );
 
     if (isLegacyPath) {
       const notice = publicContract.legacyPathNotice;
@@ -259,9 +378,7 @@ for (const pathKey of Object.keys(spec.paths).sort()) {
 }
 
 spec.paths = sortedPaths;
-spec.tags = Array.from(tagNames)
-  .sort((left, right) => left.localeCompare(right))
-  .map((name) => ({ name }));
+spec.tags = Array.from(tagDefinitions.values()).sort((left, right) => left.name.localeCompare(right.name));
 normalizeSchemaTree(spec.components?.schemas);
 
 await fs.mkdir(intermediateDir, { recursive: true });

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -318,6 +318,82 @@ function normalizeSchemaTree(node) {
   }
 }
 
+function collectComponentUsage(rootNode) {
+  const usedComponents = new Map();
+  const visitedRefs = new Set();
+
+  function mark(section, name) {
+    if (!usedComponents.has(section)) {
+      usedComponents.set(section, new Set());
+    }
+    usedComponents.get(section).add(name);
+  }
+
+  function walk(node) {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        walk(item);
+      }
+      return;
+    }
+
+    if (typeof node.$ref === "string") {
+      const ref = node.$ref;
+      const match = ref.match(/^#\/components\/([^/]+)\/(.+)$/);
+      if (match) {
+        const [, section, name] = match;
+        mark(section, name);
+
+        if (!visitedRefs.has(ref)) {
+          visitedRefs.add(ref);
+          const target = spec.components?.[section]?.[name];
+          if (target) {
+            walk(target);
+          }
+        }
+      }
+    }
+
+    for (const value of Object.values(node)) {
+      walk(value);
+    }
+  }
+
+  walk(rootNode);
+  return usedComponents;
+}
+
+function pruneUnusedSchemas() {
+  if (!spec.components?.schemas) {
+    return;
+  }
+
+  const usedComponents = collectComponentUsage({
+    paths: spec.paths,
+    webhooks: spec.webhooks,
+    components: {
+      responses: spec.components.responses,
+      parameters: spec.components.parameters,
+      requestBodies: spec.components.requestBodies,
+      headers: spec.components.headers,
+      examples: spec.components.examples,
+      links: spec.components.links,
+      callbacks: spec.components.callbacks
+    }
+  });
+  const usedSchemas = usedComponents.get("schemas") ?? new Set();
+
+  for (const schemaName of Object.keys(spec.components.schemas)) {
+    if (!usedSchemas.has(schemaName)) {
+      delete spec.components.schemas[schemaName];
+    }
+  }
+}
+
 for (const pathKey of Object.keys(spec.paths).sort()) {
   const pathItem = spec.paths[pathKey];
   const sortedPathItem = {};
@@ -380,6 +456,7 @@ for (const pathKey of Object.keys(spec.paths).sort()) {
 spec.paths = sortedPaths;
 spec.tags = Array.from(tagDefinitions.values()).sort((left, right) => left.name.localeCompare(right.name));
 normalizeSchemaTree(spec.components?.schemas);
+pruneUnusedSchemas();
 
 await fs.mkdir(intermediateDir, { recursive: true });
 await fs.writeFile(normalizedSpecPath, `${JSON.stringify(spec, null, 2)}\n`, "utf8");

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -1,0 +1,270 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const artifactsDir = path.join(rootDir, "artifacts");
+const intermediateDir = path.join(artifactsDir, "intermediate");
+const rawSpecPath = path.join(intermediateDir, "openapi-merged.raw.json");
+const normalizedSpecPath = path.join(intermediateDir, "openapi-public.normalized.json");
+const publicContractPath = path.join(rootDir, "spec", "public-contract.json");
+const metadataPath = path.join(rootDir, "spec", "operation-metadata.json");
+
+const publicContract = JSON.parse(await fs.readFile(publicContractPath, "utf8"));
+const spec = JSON.parse(await fs.readFile(rawSpecPath, "utf8"));
+
+let metadata = null;
+try {
+  metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+} catch {
+  metadata = null;
+}
+
+const defaultServerUrl =
+  process.env.PUBLIC_API_URL ||
+  (process.env.STAGING_DOCS === "true"
+    ? "https://api.staging.formaloo.com"
+    : "https://api.formaloo.me");
+const serverDescription =
+  process.env.STAGING_DOCS === "true" ? "Formaloo Staging Server" : "Formaloo Server";
+
+spec.externalDocs = spec.externalDocs ?? spec.info?.externalDocs;
+if (spec.info?.externalDocs) {
+  delete spec.info.externalDocs;
+}
+
+spec.servers = [
+  {
+    url: defaultServerUrl,
+    description: serverDescription
+  }
+];
+
+spec.components = spec.components ?? {};
+spec.components.securitySchemes = spec.components.securitySchemes ?? {};
+if (!spec.components.securitySchemes.ApiKeyAuthentication) {
+  spec.components.securitySchemes.ApiKeyAuthentication = {
+    type: "apiKey",
+    in: "header",
+    name: "x-api-key",
+    description: "Application API key required for Formaloo public API requests."
+  };
+}
+if (!spec.components.securitySchemes.JwtAuthentication) {
+  spec.components.securitySchemes.JwtAuthentication = {
+    type: "apiKey",
+    in: "header",
+    name: "Authorization",
+    description: 'Token-based authentication with required prefix "JWT"'
+  };
+}
+
+const operationMetadata = metadata?.operations ?? {};
+const allowedMetadataKeys = new Set([
+  "stability",
+  "audience",
+  "recommended",
+  "complexity",
+  "statefulness"
+]);
+const legacySessionSecuritySchemes = new Set(["cookieAuth", "basicAuth"]);
+const tagNames = new Set();
+const sortedPaths = {};
+const httpMethods = new Set(["get", "post", "put", "patch", "delete", "options", "head", "trace"]);
+
+function getRefTarget(ref) {
+  if (typeof ref !== "string" || !ref.startsWith("#/")) {
+    return null;
+  }
+
+  const parts = ref.slice(2).split("/");
+  let current = spec;
+  for (const part of parts) {
+    current = current?.[part];
+    if (!current) {
+      return null;
+    }
+  }
+
+  return current;
+}
+
+function inferSchemaType(schema, seenRefs = new Set()) {
+  if (!schema || typeof schema !== "object") {
+    return null;
+  }
+
+  if (typeof schema.type === "string") {
+    return schema.type;
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return typeof schema.enum[0] === "string" ? "string" : null;
+  }
+
+  if (typeof schema.$ref === "string") {
+    if (seenRefs.has(schema.$ref)) {
+      return null;
+    }
+
+    const nextSeenRefs = new Set(seenRefs);
+    nextSeenRefs.add(schema.$ref);
+    return inferSchemaType(getRefTarget(schema.$ref), nextSeenRefs);
+  }
+
+  for (const key of ["allOf", "oneOf", "anyOf"]) {
+    if (!Array.isArray(schema[key]) || schema[key].length === 0) {
+      continue;
+    }
+
+    const inferredTypes = new Set(
+      schema[key]
+        .map((item) => inferSchemaType(item, seenRefs))
+        .filter(Boolean)
+    );
+
+    if (inferredTypes.size === 1) {
+      return Array.from(inferredTypes)[0];
+    }
+  }
+
+  return null;
+}
+
+function normalizeSecurity(operation) {
+  if (!Array.isArray(operation.security) || operation.security.length === 0) {
+    return operation;
+  }
+
+  const knownSecuritySchemes = new Set(Object.keys(spec.components.securitySchemes ?? {}));
+  let shouldUsePublicAuthModel = false;
+  const filteredSecurity = [];
+
+  for (const requirement of operation.security) {
+    if (!requirement || typeof requirement !== "object") {
+      continue;
+    }
+
+    const keys = Object.keys(requirement);
+    if (keys.length === 0) {
+      continue;
+    }
+
+    if (keys.every((key) => legacySessionSecuritySchemes.has(key))) {
+      shouldUsePublicAuthModel = true;
+      continue;
+    }
+
+    const safeRequirement = {};
+    for (const key of keys) {
+      if (knownSecuritySchemes.has(key)) {
+        safeRequirement[key] = requirement[key];
+      }
+    }
+
+    if (Object.keys(safeRequirement).length > 0) {
+      filteredSecurity.push(safeRequirement);
+    }
+  }
+
+  if (shouldUsePublicAuthModel) {
+    filteredSecurity.push({
+      ApiKeyAuthentication: [],
+      JwtAuthentication: []
+    });
+  }
+
+  if (filteredSecurity.length > 0) {
+    operation.security = filteredSecurity;
+  } else {
+    delete operation.security;
+  }
+
+  return operation;
+}
+
+function normalizeSchemaTree(node) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+
+  if (node.nullable === true && typeof node.type !== "string") {
+    const inferredType = inferSchemaType(node);
+    if (inferredType) {
+      node.type = inferredType;
+    }
+  }
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        normalizeSchemaTree(item);
+      }
+    } else if (value && typeof value === "object") {
+      normalizeSchemaTree(value);
+    }
+  }
+}
+
+for (const pathKey of Object.keys(spec.paths).sort()) {
+  const pathItem = spec.paths[pathKey];
+  const sortedPathItem = {};
+  const isLegacyPath = Boolean(publicContract.legacyPaths[pathKey]);
+
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!httpMethods.has(method)) {
+      sortedPathItem[method] = operation;
+      continue;
+    }
+
+    const normalizedOperation = { ...operation };
+    normalizeSecurity(normalizedOperation);
+
+    if (!Array.isArray(normalizedOperation.tags) || normalizedOperation.tags.length === 0) {
+      const firstSegment = pathKey.split("/").filter(Boolean)[1] ?? "general";
+      normalizedOperation.tags = [firstSegment];
+    }
+
+    for (const tag of normalizedOperation.tags) {
+      tagNames.add(tag);
+    }
+
+    if (isLegacyPath) {
+      const notice = publicContract.legacyPathNotice;
+      const existingDescription = (normalizedOperation.description ?? "").trim();
+      if (!existingDescription.startsWith(notice)) {
+        normalizedOperation.description = existingDescription
+          ? `${notice}\n\n${existingDescription}`
+          : notice;
+      }
+      normalizedOperation["x-formaloo-legacy-path"] = true;
+    }
+
+    if (normalizedOperation.operationId && operationMetadata[normalizedOperation.operationId]) {
+      const safeMetadata = {};
+      for (const [key, value] of Object.entries(operationMetadata[normalizedOperation.operationId])) {
+        if (allowedMetadataKeys.has(key)) {
+          safeMetadata[key] = value;
+        }
+      }
+
+      if (Object.keys(safeMetadata).length > 0) {
+        normalizedOperation["x-formaloo-metadata"] = safeMetadata;
+      }
+    }
+
+    sortedPathItem[method] = normalizedOperation;
+  }
+
+  sortedPaths[pathKey] = sortedPathItem;
+}
+
+spec.paths = sortedPaths;
+spec.tags = Array.from(tagNames)
+  .sort((left, right) => left.localeCompare(right))
+  .map((name) => ({ name }));
+normalizeSchemaTree(spec.components?.schemas);
+
+await fs.mkdir(intermediateDir, { recursive: true });
+await fs.writeFile(normalizedSpecPath, `${JSON.stringify(spec, null, 2)}\n`, "utf8");
+
+console.log(`Normalized public spec -> ${path.relative(rootDir, normalizedSpecPath)}`);

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -9,6 +9,13 @@ const normalizedSpecPath = path.join(intermediateDir, "openapi-public.normalized
 const publicContractPath = path.join(rootDir, "spec", "public-contract.json");
 const metadataPath = path.join(rootDir, "spec", "operation-metadata.json");
 const tagMetadataPath = path.join(rootDir, "spec", "tag-metadata.json");
+const apiKeyHeaderDescription = "Your API Key from the Formaloo dashboard.";
+const workspaceHeaderDescription =
+  "Current workspace identifier for workspace-scoped requests. Send this header when the endpoint requires a workspace context and your API key does not already identify the workspace.";
+const clientCredentialsAuthorizationDescription =
+  "Use `Basic {API Secret}`. The API Secret shown in the Formaloo dashboard can be used directly here.";
+const endUserSessionAuthorizationDescription =
+  "Use the end-user session token returned by the sign-in flow.";
 
 const publicContract = JSON.parse(await fs.readFile(publicContractPath, "utf8"));
 const spec = JSON.parse(await fs.readFile(rawSpecPath, "utf8"));
@@ -55,7 +62,7 @@ if (!spec.components.securitySchemes.ApiKeyAuthentication) {
     type: "apiKey",
     in: "header",
     name: "x-api-key",
-    description: "Application API key required for Formaloo public API requests."
+    description: apiKeyHeaderDescription
   };
 }
 if (!spec.components.securitySchemes.JwtAuthentication) {
@@ -63,7 +70,7 @@ if (!spec.components.securitySchemes.JwtAuthentication) {
     type: "apiKey",
     in: "header",
     name: "Authorization",
-    description: 'Token-based authentication with required prefix "JWT"'
+    description: 'Use `JWT {Authorization Token}` for protected Formaloo API requests.'
   };
 }
 spec.components.responses.BadRequest = spec.components.responses.BadRequest ?? {
@@ -130,6 +137,25 @@ function hasHeaderParameter(operation, headerName) {
   );
 }
 
+function upsertHeaderParameter(operation, parameter) {
+  operation.parameters = operation.parameters ?? [];
+  const existingParameter = operation.parameters.find(
+    (currentParameter) =>
+      currentParameter?.in === "header" &&
+      typeof currentParameter?.name === "string" &&
+      currentParameter.name.toLowerCase() === parameter.name.toLowerCase()
+  );
+
+  if (existingParameter) {
+    existingParameter.description = parameter.description;
+    existingParameter.required = parameter.required;
+    existingParameter.schema = parameter.schema;
+    return;
+  }
+
+  operation.parameters.push(parameter);
+}
+
 function ensureResponse(operation, statusCode, refName) {
   operation.responses = operation.responses ?? {};
   if (!operation.responses[statusCode]) {
@@ -160,6 +186,44 @@ function ensureResponseDescriptions(operation, method) {
     response.description =
       defaults[statusCode] ??
       (method === "delete" ? "Request completed successfully." : "Successful response.");
+  }
+}
+
+function normalizeHeaderParameters(pathKey, method, operation) {
+  for (const parameter of operation.parameters ?? []) {
+    if (parameter?.in !== "header" || typeof parameter?.name !== "string") {
+      continue;
+    }
+
+    const normalizedName = parameter.name.toLowerCase();
+
+    if (normalizedName === "x-api-key") {
+      parameter.description = apiKeyHeaderDescription;
+    }
+
+    if (normalizedName === "x-workspace") {
+      parameter.description = workspaceHeaderDescription;
+    }
+  }
+
+  if (pathKey === "/v3.0/oauth2/authorization-token/" && method === "post") {
+    upsertHeaderParameter(operation, {
+      in: "header",
+      name: "Authorization",
+      required: true,
+      schema: { type: "string" },
+      description: clientCredentialsAuthorizationDescription
+    });
+  }
+
+  if (pathKey === "/v1.0/end-users/authorize/" && method === "post") {
+    upsertHeaderParameter(operation, {
+      in: "header",
+      name: "Authorization",
+      required: true,
+      schema: { type: "string" },
+      description: endUserSessionAuthorizationDescription
+    });
   }
 }
 
@@ -406,6 +470,7 @@ for (const pathKey of Object.keys(spec.paths).sort()) {
     }
 
     const normalizedOperation = { ...operation };
+    normalizeHeaderParameters(pathKey, method, normalizedOperation);
     normalizeSecurity(normalizedOperation);
     normalizeResponses(pathKey, method, normalizedOperation);
 

--- a/scripts/prepare-doc-stubs.mjs
+++ b/scripts/prepare-doc-stubs.mjs
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const specDir = path.join(rootDir, "spec");
+const artifactsDir = path.join(rootDir, "artifacts", "intermediate");
+const manifestPath = path.join(artifactsDir, "generated-doc-stubs.txt");
+const specFiles = [
+  "icas.yaml",
+  "formz.yaml",
+  "authentication.yaml",
+  "storage.yaml",
+  "ai.yaml"
+];
+
+const docPattern = /docs[^\s'"]+?\.md/g;
+const referenced = new Set();
+const created = new Set();
+
+await fs.mkdir(artifactsDir, { recursive: true });
+
+for (const fileName of specFiles) {
+  const filePath = path.join(specDir, fileName);
+
+  try {
+    const contents = await fs.readFile(filePath, "utf8");
+    const matches = contents.match(docPattern) ?? [];
+
+    for (const docRef of matches) {
+      const outputPath = path.join(specDir, docRef);
+      if (referenced.has(outputPath)) {
+        continue;
+      }
+
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      referenced.add(outputPath);
+
+      try {
+        await fs.access(outputPath);
+      } catch {
+        await fs.writeFile(outputPath, "", "utf8");
+        created.add(outputPath);
+      }
+    }
+  } catch (error) {
+    console.warn(`Skipping doc stub generation for ${fileName}: ${error.message}`);
+  }
+}
+
+await fs.writeFile(
+  manifestPath,
+  [...created].sort().join("\n") + ([...created].length > 0 ? "\n" : ""),
+  "utf8"
+);
+
+console.log(
+  `Prepared ${referenced.size} documentation stub paths (${created.size} newly created).`
+);

--- a/scripts/validate-openapi.mjs
+++ b/scripts/validate-openapi.mjs
@@ -53,6 +53,12 @@ if (!Array.isArray(spec.tags) || spec.tags.length === 0) {
   errors.push("Final normalized spec must define at least one top-level tag.");
 }
 
+for (const tag of spec.tags ?? []) {
+  if (typeof tag.description !== "string" || tag.description.trim() === "") {
+    errors.push(`Top-level tag ${tag.name} must define a non-empty description.`);
+  }
+}
+
 for (const pathKey of Object.keys(spec.paths)) {
   if (!pathKey.startsWith(defaultPrefix) && !legacyPaths.has(pathKey)) {
     errors.push(`Path ${pathKey} is outside the public default version and is not allowlisted as a legacy exception.`);
@@ -70,6 +76,11 @@ for (const pathKey of Object.keys(spec.paths)) {
           errors.push(`Operation ${method.toUpperCase()} ${pathKey} references undefined security scheme ${schemeName}.`);
         }
       }
+    }
+
+    const has4xxResponse = Object.keys(operation.responses ?? {}).some((statusCode) => /^4\d\d$/.test(statusCode));
+    if (!has4xxResponse) {
+      errors.push(`Operation ${method.toUpperCase()} ${pathKey} must define at least one 4XX response.`);
     }
 
     if (legacyPaths.has(pathKey)) {

--- a/scripts/validate-openapi.mjs
+++ b/scripts/validate-openapi.mjs
@@ -1,0 +1,139 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const artifactsDir = path.join(rootDir, "artifacts");
+const validationDir = path.join(artifactsDir, "validation");
+const normalizedSpecPath = path.join(artifactsDir, "intermediate", "openapi-public.normalized.json");
+const publicContractPath = path.join(rootDir, "spec", "public-contract.json");
+const introPath = path.join(rootDir, "spec", "docs", "v3.0", "intro.md");
+const metadataPath = path.join(rootDir, "spec", "operation-metadata.json");
+const finalYamlPath = path.join(rootDir, "openapi-v3.0.yaml");
+
+const allowedMetadataKeys = new Set([
+  "stability",
+  "audience",
+  "recommended",
+  "complexity",
+  "statefulness"
+]);
+
+const spec = JSON.parse(await fs.readFile(normalizedSpecPath, "utf8"));
+const publicContract = JSON.parse(await fs.readFile(publicContractPath, "utf8"));
+const introContents = await fs.readFile(introPath, "utf8");
+
+const errors = [];
+const warnings = [];
+const defaultPrefix = publicContract.defaultVersionPrefix;
+const legacyPaths = new Set(Object.keys(publicContract.legacyPaths));
+const knownSecuritySchemes = new Set(Object.keys(spec.components?.securitySchemes ?? {}));
+
+const introDisallowedPatterns = [
+  /https:\/\/api\.formaloo\.me\/v1\.0\//,
+  /https:\/\/api\.formaloo\.me\/v2\.0\//,
+  /v1\.0\/oauth2\/authorization-token/,
+  /v2\.0\/oauth2\/authorization-token/
+];
+
+for (const pattern of introDisallowedPatterns) {
+  if (pattern.test(introContents)) {
+    errors.push(`Public intro contains stale version example matching ${pattern}`);
+  }
+}
+
+if (spec.info?.externalDocs) {
+  errors.push("OpenAPI info.externalDocs should not be present in the final normalized spec.");
+}
+
+if (!spec.externalDocs) {
+  warnings.push("Final normalized spec does not define top-level externalDocs.");
+}
+
+if (!Array.isArray(spec.tags) || spec.tags.length === 0) {
+  errors.push("Final normalized spec must define at least one top-level tag.");
+}
+
+for (const pathKey of Object.keys(spec.paths)) {
+  if (!pathKey.startsWith(defaultPrefix) && !legacyPaths.has(pathKey)) {
+    errors.push(`Path ${pathKey} is outside the public default version and is not allowlisted as a legacy exception.`);
+  }
+
+  const pathItem = spec.paths[pathKey];
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!["get", "post", "put", "patch", "delete", "options", "head", "trace"].includes(method)) {
+      continue;
+    }
+
+    for (const requirement of operation.security ?? []) {
+      for (const schemeName of Object.keys(requirement ?? {})) {
+        if (!knownSecuritySchemes.has(schemeName)) {
+          errors.push(`Operation ${method.toUpperCase()} ${pathKey} references undefined security scheme ${schemeName}.`);
+        }
+      }
+    }
+
+    if (legacyPaths.has(pathKey)) {
+      if (!operation["x-formaloo-legacy-path"]) {
+        errors.push(`Legacy path ${method.toUpperCase()} ${pathKey} is missing x-formaloo-legacy-path.`);
+      }
+    }
+  }
+}
+
+try {
+  await fs.access(finalYamlPath);
+} catch {
+  errors.push("Final YAML artifact openapi-v3.0.yaml was not generated.");
+}
+
+try {
+  const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+  const operations = metadata?.operations ?? {};
+
+  for (const [operationId, definition] of Object.entries(operations)) {
+    for (const key of Object.keys(definition)) {
+      if (!allowedMetadataKeys.has(key)) {
+        errors.push(`Operation metadata for ${operationId} contains unsupported key ${key}.`);
+      }
+    }
+  }
+} catch {
+  // optional file
+}
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  defaultVersionPrefix: defaultPrefix,
+  pathCount: Object.keys(spec.paths ?? {}).length,
+  topLevelTagCount: spec.tags?.length ?? 0,
+  legacyPathCount: Object.keys(spec.paths ?? {}).filter((pathKey) => legacyPaths.has(pathKey)).length,
+  errors,
+  warnings
+};
+
+const markdownLines = [
+  "# Public contract validation summary",
+  "",
+  `- Generated at: ${summary.generatedAt}`,
+  `- Path count: ${summary.pathCount}`,
+  `- Top-level tag count: ${summary.topLevelTagCount}`,
+  `- Legacy path count: ${summary.legacyPathCount}`,
+  "",
+  "## Errors",
+  ...(errors.length > 0 ? errors.map((error) => `- ${error}`) : ["- None"]),
+  "",
+  "## Warnings",
+  ...(warnings.length > 0 ? warnings.map((warning) => `- ${warning}`) : ["- None"]),
+  ""
+];
+
+await fs.mkdir(validationDir, { recursive: true });
+await fs.writeFile(path.join(validationDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+await fs.writeFile(path.join(validationDir, "summary.md"), markdownLines.join("\n"), "utf8");
+
+if (errors.length > 0) {
+  console.error(markdownLines.join("\n"));
+  process.exit(1);
+}
+
+console.log(markdownLines.join("\n"));

--- a/spec/docs/v3.0/end-users/authorize/post.md
+++ b/spec/docs/v3.0/end-users/authorize/post.md
@@ -2,6 +2,8 @@ Exchange an end-user session token for an authorization token.
 
 Use this endpoint after the end user has completed the login flow and you have received a valid session token.
 
+This flow is used for login-enabled public experiences such as client portals, apps, or forms that support end-user sign-in.
+
 ## Required headers
 
 - `x-api-key`: your API Key

--- a/spec/docs/v3.0/end-users/authorize/post.md
+++ b/spec/docs/v3.0/end-users/authorize/post.md
@@ -1,1 +1,12 @@
-Creates a new obtain authorization token.
+Exchange an end-user session token for an authorization token.
+
+Use this endpoint after the end user has completed the login flow and you have received a valid session token.
+
+## Required headers
+
+- `x-api-key`: your API Key
+- `Authorization`: the end-user session token returned by the login flow
+
+## Response
+
+The response includes an authorization token that you can send on later protected requests for that signed-in end user.

--- a/spec/docs/v3.0/end-users/confirm-login/post.md
+++ b/spec/docs/v3.0/end-users/confirm-login/post.md
@@ -1,1 +1,7 @@
-Creates a new confirm o auth2 token login.
+Confirm the end-user login flow after the user returns from sign-in.
+
+Use this endpoint with the login confirmation data returned by the end-user authentication flow.
+
+## What happens next
+
+After a successful confirmation, exchange the resulting session token on the documented end-user authorization endpoint to obtain an authorization token for subsequent protected requests.

--- a/spec/docs/v3.0/end-users/profile/get.md
+++ b/spec/docs/v3.0/end-users/profile/get.md
@@ -1,1 +1,3 @@
-Retrieves the specified end user profile.
+Retrieve the signed-in end user's profile.
+
+In client portal or public app flows, you may also send `x-scope` when the current app uses scope-based authentication context. This header is optional and only applies to scope-aware portal scenarios.

--- a/spec/docs/v3.0/end-users/request-redirect/post.md
+++ b/spec/docs/v3.0/end-users/request-redirect/post.md
@@ -1,2 +1,11 @@
+Start the end-user sign-in flow for a public app or portal.
+
+Use this endpoint when your own users need to sign in before they can access protected app content or profile data.
+
 ## Sent data
-The `originator` is the board's share address (same address used to get the boards data).
+
+The `originator` identifies the public app or board that is requesting sign-in. In most integrations, this is the same share address or public identifier you already use to load the app.
+
+## What happens next
+
+After the user completes the sign-in flow, use the returned login confirmation data with the documented end-user login confirmation and authorization endpoints to obtain an authorization token for that end user.

--- a/spec/docs/v3.0/end-users/request-redirect/post.md
+++ b/spec/docs/v3.0/end-users/request-redirect/post.md
@@ -6,6 +6,8 @@ Use this endpoint when your own users need to sign in before they can access pro
 
 The `originator` identifies the public app or board that is requesting sign-in. In most integrations, this is the same share address or public identifier you already use to load the app.
 
+If your client portal uses scoped authentication, you may also send `x-scope` to identify the scope for this sign-in request. This header is optional and only applies to scope-aware public app flows.
+
 ## What happens next
 
 After the user completes the sign-in flow, use the returned login confirmation data with the documented end-user login confirmation and authorization endpoints to obtain an authorization token for that end user.

--- a/spec/docs/v3.0/form-displays/slug/slug/submit/post.md
+++ b/spec/docs/v3.0/form-displays/slug/slug/submit/post.md
@@ -94,7 +94,17 @@ To submit a form using field aliases, you must:
 
 ## Authorization and Authentication
 
-In order to submit a form using this endpoint, you don't have to send an `Authorization` header, but you should send the `x-api-key` header to identify your application.
+In order to submit a form using this endpoint, you do not usually need to send an `Authorization` header. You should send the `x-api-key` header to identify your application.
+
+This endpoint is designed for public submission scenarios, including:
+
+- normal public forms with no login requirement
+- forms embedded inside a client portal or public app
+- login-enabled forms where the user is submitting through the public form flow
+
+If your app or portal provides an app identifier, you may also send `x-app-id`. This header is optional and is only relevant in client portal or public app contexts.
+
+If you need to create rows through an authenticated private API flow instead of the public submission flow, use the authenticated row-creation endpoint.
 
 ## Notes
 

--- a/spec/docs/v3.0/forms/slug/rows/post.md
+++ b/spec/docs/v3.0/forms/slug/rows/post.md
@@ -94,7 +94,15 @@ To submit a form using field aliases, you must:
 
 ## Authorization and Authentication
 
-In order to add a form to a row using this endpoint, you have to send both the `Authorization` and `x-api-key` headers to identify your use and application. You can only add rows to the forms that you have access to. If you don't want to send the `Authorization` header for any reason, you can use the form submission endpoint.
+In order to add a row using this endpoint, you have to send both the `Authorization` and `x-api-key` headers to identify your user and application. You can only add rows to forms that your authenticated client has access to.
+
+Use this endpoint for authenticated private API access, such as dashboard or workspace-scoped integrations.
+
+If you are handling a public submission scenario instead, use the form submission endpoint. That flow is typically a better fit for:
+
+- anonymous form submissions
+- login-enabled forms that are submitted through the public form experience
+- forms shown inside a client portal or public app
 
 ## Notes
 

--- a/spec/docs/v3.0/intro.md
+++ b/spec/docs/v3.0/intro.md
@@ -9,6 +9,7 @@ Most public endpoints use the `v3.0` path. A small number of endpoints remain av
 To call the API, you need:
 
 - an **API Key** sent with the `x-api-key` header
+- an **API Secret** from the dashboard
 - an **Authorization Token** for endpoints that require authenticated access
 
 ## Getting your keys
@@ -19,13 +20,24 @@ You can manage your keys from the Formaloo dashboard:
 - Open your profile menu
 - Select **API Key & Token**
 
-## Getting an Authorization Token
+The dashboard shows both:
 
-Use your **Secret Key** to request an **Authorization Token** from the documented authorization endpoint.
+- **API Key**: send this with the `x-api-key` header
+- **API Secret**: use this to obtain an authorization token for protected endpoints
+
+## Direct API access
+
+If you are building a server-to-server integration, automation, or backend client, use your dashboard-issued API Key and API Secret.
+
+### Step 1: Request an authorization token
+
+Use your **API Secret** to request an **Authorization Token** from the documented authorization endpoint.
 
 Request headers:
 
-`Authorization = Basic {Secret Key}`
+`x-api-key = {API Key}`
+
+`Authorization = Basic {API Secret}`
 
 Request body:
 
@@ -35,7 +47,8 @@ Example:
 
 ```bash
 curl --location --request POST 'https://api.formaloo.me/v3.0/oauth2/authorization-token/' \
---header 'Authorization: Basic {Secret Key}' \
+--header 'x-api-key: {API Key}' \
+--header 'Authorization: Basic {API Secret}' \
 --form 'grant_type="client_credentials"'
 ```
 
@@ -47,7 +60,9 @@ Example response:
 }
 ```
 
-## Calling the API
+Use the **API Secret** exactly as shown in the dashboard for the `Basic` authorization header.
+
+### Step 2: Call protected endpoints
 
 Include your API Key in every request unless an endpoint explicitly documents a different requirement.
 
@@ -67,6 +82,25 @@ curl 'https://api.formaloo.me/v3.0/forms/' \
 ```
 
 Some endpoints are public and do not require the `Authorization` header. Always follow the requirements shown on the endpoint you are calling.
+
+## End-user authentication
+
+If you are building a public app, user portal, or any flow where your own users sign in, use the end-user authentication endpoints in this reference instead of the client-credentials flow above.
+
+Typical end-user flow:
+
+1. Request a login or redirect URL.
+2. Complete the user sign-in flow and receive a session token or login confirmation.
+3. Exchange that session token for an authorization token on the documented end-user authorization endpoint.
+4. Use the returned authorization token with your `x-api-key` when calling protected end-user endpoints.
+
+Some end-user authentication endpoints remain on documented legacy paths for compatibility. Follow the exact path shown on each endpoint page.
+
+## Workspace-scoped requests
+
+Some endpoints are scoped to a workspace. When an endpoint documents the `x-workspace` header, send the current workspace identifier for the workspace you want to act on.
+
+In many integrations, a workspace-bound API key already identifies the workspace. If the endpoint description says the header is optional for your API key, you can omit it in that case.
 
 ## Contributing
 

--- a/spec/docs/v3.0/intro.md
+++ b/spec/docs/v3.0/intro.md
@@ -1,150 +1,73 @@
-This is the documentations for using **Formaloo**'s REST APIs. You can use Formaloo's REST API by getting your *API Key* and *Secret Key* from your panel, and by using this documentation.
+This documentation covers the Formaloo public API.
 
-<br>
-<br>
+## Getting started
 
-# Get started with the API
+Use the version shown in this reference when calling an endpoint.
 
-## Getting your Keys
+Most public endpoints use the `v3.0` path. A small number of endpoints remain available on documented legacy paths for compatibility. When an endpoint in this reference uses a legacy path, use the exact path shown on that endpoint.
 
-In order to use Formaloo's REST API, first you need to get your API Key and Secret Key form your dashboard. Follow these steps to get your keys:
+To call the API, you need:
 
-- Login (or signup) in [Formaloo's dashboard](https://dash.formaloo.net/u).
-- Click on the profile icon on the top right corner of the dashboard.
-- Choose the **API Key & Token** item from the list.
+- an **API Key** sent with the `x-api-key` header
+- an **Authorization Token** for endpoints that require authenticated access
 
-<br>
+## Getting your keys
 
-**API Key:** This key is used to identify your application and the integration you're using. You have to include it in all requests, with the header `x-api-key`
+You can manage your keys from the Formaloo dashboard:
 
-**Secret Key:** You will need this key to acquire the Authorization Tokens, sent in all requests. Please note that the Authorization Token has a short lifetime and will be expired after 30 seconds, but the **Secret Key** will not be expired and can be used to acquire as many Authorization Tokens as you want.
+- Sign in to [Formaloo Dashboard](https://dash.formaloo.net/u)
+- Open your profile menu
+- Select **API Key & Token**
 
-<br>
+## Getting an Authorization Token
 
-## Get Authorization Token
+Use your **Secret Key** to request an **Authorization Token** from the documented authorization endpoint.
 
-The next step is to use your **Secret Key** to acquire an **Authorization Token.** In order to do so, you have to simply send a post requests to the following endpoint: `https://api.formaloo.me/v3.0/oauth2/authorization-token/`
-
-Your request should contain this header and body:
-
-**Header:**
+Request headers:
 
 `Authorization = Basic {Secret Key}`
 
-**Body (form-data):**
+Request body:
 
 `grant_type=client_credentials`
 
-<br>
+Example:
 
-**Example (cURL)**
-
-``` json
-curl --location --request POST 'https://api.formaloo.me/v1.0/oauth2/authorization-token/' \
+```bash
+curl --location --request POST 'https://api.formaloo.me/v3.0/oauth2/authorization-token/' \
 --header 'Authorization: Basic {Secret Key}' \
 --form 'grant_type="client_credentials"'
 ```
 
-<br>
+Example response:
 
-
-**Example (Python)**
-
-``` json
-import requests
-
-url = "https://api.formaloo.me/v3.0/oauth2/authorization-token/"
-
-payload={'grant_type': 'client_credentials'}
-headers = {
-  'Authorization': f'Basic {secret_key}' 
-}
-
-response = requests.post(
-    url, 
-    headers=headers, 
-    data=payload
-)
-
-if response.status==200:
-	authorization_token = response.json().get('authorization_token')
-```
-
-<br>
-
-**Response**
-
-``` json
+```json
 {
-    "authorization_token": "{Authorization Token}"
+  "authorization_token": "{Authorization Token}"
 }
 ```
 
-<br>
+## Calling the API
 
-If your **Secret Key** is valid and you’re sending the request properly, you will receive an **Authorization Token** in the response, which you can use to call the API before it expires and needs to be refreshed.
+Include your API Key in every request unless an endpoint explicitly documents a different requirement.
 
-<br>
+For authenticated endpoints, include:
 
-## Call Formaloo’s API
-
-In this step, you have a valid **API Key** and an active **Authorization Token.** All you need to do now is to include each in the proper header to authenticate your API call:
-
-<br>
-
-**Header:**
-
-``` json
+```text
 Authorization = JWT {Authorization Token}
 x-api-key = {API Key}
 ```
 
-<br>
+Example:
 
-Please note that all the APIs (except the authorization API) need the `x-api-key` header, while some (e.g. submitting a form) don’t need the `Authorization` header. Refer to the  API documentation to see which endpoints don’t need the `Authorization` header.
-
-<br>
-
-**Request Example (cURL):**
-
-``` json
-
+```bash
 curl 'https://api.formaloo.me/v3.0/forms/' \
 --header 'x-api-key: {API Key}' \
 --header 'Authorization: JWT {Authorization Token}'
 ```
 
-<br>
+Some endpoints are public and do not require the `Authorization` header. Always follow the requirements shown on the endpoint you are calling.
 
-**Request Example (Python):**
+## Contributing
 
-``` json
-import requests
-
-url = "https://api.formaloo.me/v3.0/forms/"
-
-headers = {
-  'x-api-key': f'{api_key}',
-  'Authorization': f'JWT {authorization_token}'
-}
-
-response = requests.get(
-    url, 
-    headers=headers
-)
-```
-
-<br>
-<br>
-
-# Contribution
-You can make this documentation better and more complete by helping us in writing this document. You can visit our [API documentation's GitHub repository](https://github.com/formaloo/formaloo-api-documentations) and add/edit the description for any of the endpoints.The next step is to use your **Secret Key** to acquire an **Authorization Token.** In order to do so, you have to simply send a post requests to the following endpoint: `https://api.formaloo.me/v2.0/oauth2/authorization-token/`
-url = "https://api.formaloo.me/v2.0/oauth2/authorization-token/"
-curl 'https://api.formaloo.me/v2.0/forms/' \
-url = "https://api.formaloo.me/v2.0/forms/"
-The next step is to use your **Secret Key** to acquire an **Authorization Token.** In order to do so, you have to simply send a post requests to the following endpoint: `https://api.formaloo.me/v1.0/oauth2/authorization-token/`
-url = "https://api.formaloo.me/v1.0/oauth2/authorization-token/"
-curl 'https://api.formaloo.me/v1.0/forms/' \
-url = "https://api.formaloo.me/v1.0/forms/"
-The next step is to use your **Secret Key** to acquire an **Authorization Token.** In order to do so, you have to simply send a post requests to the following endpoint: `https://api.formaloo.me/v2.0/oauth2/authorization-token/`
-You can make this documentation better and more complete by helping us in writing this document. You can visit our [API documentation's GitHub repository](https://github.com/formaloo/formaloo-api-documentations) and add/edit the description for any of the endpoints.
+This repository combines generated public API specifications with manual endpoint descriptions. Contributions should improve the public contract and the consumer-facing documentation without adding internal implementation details.

--- a/spec/docs/v3.0/intro.md
+++ b/spec/docs/v3.0/intro.md
@@ -102,6 +102,15 @@ Some endpoints are scoped to a workspace. When an endpoint documents the `x-work
 
 In many integrations, a workspace-bound API key already identifies the workspace. If the endpoint description says the header is optional for your API key, you can omit it in that case.
 
+## Client portal headers
+
+Some public app or client portal endpoints may also document optional headers such as `x-scope` or `x-app-id`.
+
+- `x-scope` is used on some login-enabled public app flows to identify the scope of the current portal experience.
+- `x-app-id` is used on some public app form submission flows when the app provides a specific app identifier.
+
+Only send these headers when the endpoint documentation for your scenario calls for them.
+
 ## Contributing
 
 This repository combines generated public API specifications with manual endpoint descriptions. Contributions should improve the public contract and the consumer-facing documentation without adding internal implementation details.

--- a/spec/docs/v3.0/oauth2/authorization-token/post.md
+++ b/spec/docs/v3.0/oauth2/authorization-token/post.md
@@ -1,2 +1,20 @@
-Creates a new authorization token.
+Create an authorization token for your Formaloo API client.
 
+Use this endpoint when your integration needs to call protected API endpoints on behalf of your application.
+
+## Required headers
+
+- `x-api-key`: your API Key from the Formaloo dashboard
+- `Authorization: Basic {API Secret}`: your API Secret from the Formaloo dashboard
+
+## Required body
+
+Send:
+
+`grant_type=client_credentials`
+
+## Response
+
+The response includes an authorization token that you can use on later requests:
+
+`Authorization: JWT {Authorization Token}`

--- a/spec/openapi-merge-v3.0.json
+++ b/spec/openapi-merge-v3.0.json
@@ -1,23 +1,23 @@
 {
   "inputs": [
     {
-      "inputFile": "./v3.0-bundeled.yaml"
+      "inputFile": "./v3.0-bundled.json"
     },
     {
-      "inputFile": "./icas-bundeled.yaml"
+      "inputFile": "./icas-bundled.json"
     },
     {
-      "inputFile": "./formz-bundeled.yaml"
+      "inputFile": "./formz-bundled.json"
     },
     {
-      "inputFile": "./authentication-bundeled.yaml"
+      "inputFile": "./authentication-bundled.json"
     },
     {
-      "inputFile": "./storage-bundeled.yaml"
+      "inputFile": "./storage-bundled.json"
     },
     {
-      "inputFile": "./ai-bundeled.yaml"
+      "inputFile": "./ai-bundled.json"
     }
   ], 
-  "output": "../openapi-v3.0.yaml"
+  "output": "../artifacts/intermediate/openapi-merged.raw.json"
 }

--- a/spec/public-contract.json
+++ b/spec/public-contract.json
@@ -1,0 +1,22 @@
+{
+  "defaultVersionPrefix": "/v3.0/",
+  "legacyPathNotice": "**Legacy public path:** This endpoint remains available on the documented path for compatibility. Use the exact path shown here.",
+  "legacyPaths": {
+    "/v1.0/business-engines/": "Legacy public path",
+    "/v1.0/business-engines/{id}/": "Legacy public path",
+    "/v1.0/businesses/top-usage/": "Legacy public path",
+    "/v1.0/businesses/{businessSlug}/usage/": "Legacy public path",
+    "/v1.0/conversations/{conversationId}/history/": "Legacy public path",
+    "/v1.0/custom-prompt-analyzes/": "Legacy public path",
+    "/v1.0/custom-prompt-results/": "Legacy public path",
+    "/v1.0/custom-prompt-results/{slug}/": "Legacy public path",
+    "/v1.0/end-users/authorize/": "Legacy public path",
+    "/v1.0/end-users/reset-password-confirms/": "Legacy public path",
+    "/v1.0/end-users/reset-password-requests/": "Legacy public path",
+    "/v1.0/engines/": "Legacy public path",
+    "/v1.0/files/": "Legacy public path",
+    "/v1.0/profiles/me/": "Legacy public path",
+    "/v1.0/prompts/{slug}/": "Legacy public path",
+    "/v1.0/prompts/{slug}/ai-requests/": "Legacy public path"
+  }
+}

--- a/spec/tag-metadata.json
+++ b/spec/tag-metadata.json
@@ -1,0 +1,226 @@
+{
+  "forms": {
+    "displayName": "Forms",
+    "description": "Create, update, and manage forms and their primary configuration."
+  },
+  "fields": {
+    "displayName": "Fields",
+    "description": "Read and manage field definitions used by forms and boards."
+  },
+  "boards": {
+    "displayName": "Boards",
+    "description": "Create, browse, and manage boards and their related resources."
+  },
+  "boards-search": {
+    "displayName": "Board Search",
+    "description": "Search board resources and related results."
+  },
+  "blue-prints": {
+    "displayName": "Blueprints",
+    "description": "Browse and manage blueprint resources."
+  },
+  "shared-boards": {
+    "displayName": "Shared Boards",
+    "description": "Access public and shared board views, profile data, and shared content."
+  },
+  "conversations": {
+    "displayName": "Conversations",
+    "description": "Read conversation resources and related history."
+  },
+  "custom-prompt-analyzes": {
+    "displayName": "Custom Prompt Analyses",
+    "description": "Run analyses for custom prompts."
+  },
+  "custom-prompt-results": {
+    "displayName": "Custom Prompt Results",
+    "description": "Read stored results for custom prompt runs."
+  },
+  "dashboard-search": {
+    "displayName": "Dashboard Search",
+    "description": "Search dashboard resources exposed by the public API."
+  },
+  "draft-rows": {
+    "displayName": "Draft Rows",
+    "description": "Manage draft row submissions before they are finalized."
+  },
+  "rows": {
+    "displayName": "Rows",
+    "description": "Read, update, reorder, and manage submitted row data."
+  },
+  "form-displays": {
+    "displayName": "Form Displays",
+    "description": "Access form display endpoints, including public submission flows."
+  },
+  "private-files": {
+    "displayName": "Private Files",
+    "description": "Create and retrieve private file resources and access URLs."
+  },
+  "files": {
+    "displayName": "Files",
+    "description": "Upload and manage file resources."
+  },
+  "force-updates": {
+    "displayName": "Force Updates",
+    "description": "Trigger or inspect force-update resources."
+  },
+  "end-users": {
+    "displayName": "End Users",
+    "description": "Authenticate end users and manage end-user account flows."
+  },
+  "email-templates": {
+    "displayName": "Email Templates",
+    "description": "Create and manage reusable email templates."
+  },
+  "email-template-examples": {
+    "displayName": "Email Template Examples",
+    "description": "Inspect example payloads and samples for email templates."
+  },
+  "email-servers": {
+    "displayName": "Email Servers",
+    "description": "Manage email server configuration resources."
+  },
+  "available-email-servers": {
+    "displayName": "Available Email Servers",
+    "description": "List available email server options."
+  },
+  "emails": {
+    "displayName": "Emails",
+    "description": "Access email delivery and webhook-related resources."
+  },
+  "profiles": {
+    "displayName": "Profiles",
+    "description": "Read and update user profile information."
+  },
+  "profile": {
+    "displayName": "Profile",
+    "description": "Manage the authenticated profile and related settings."
+  },
+  "businesses": {
+    "displayName": "Businesses",
+    "description": "Manage workspace-level business resources, usage, and related entities."
+  },
+  "folders": {
+    "displayName": "Folders",
+    "description": "Create and organize folders used to group content."
+  },
+  "folder-users": {
+    "displayName": "Folder Users",
+    "description": "Manage folder user access and related membership resources."
+  },
+  "plans": {
+    "displayName": "Plans",
+    "description": "List and inspect available plans and plan-related visibility rules."
+  },
+  "oauth2": {
+    "displayName": "OAuth 2.0",
+    "description": "Request and refresh authorization tokens for authenticated API access."
+  },
+  "integration-apps": {
+    "displayName": "Integration Apps",
+    "description": "Browse and manage integration app definitions."
+  },
+  "integrations": {
+    "displayName": "Integrations",
+    "description": "Manage integration endpoints and connected integrations."
+  },
+  "integration-tags": {
+    "displayName": "Integration Tags",
+    "description": "List and manage tags used for integrations."
+  },
+  "hubspot-integrations": {
+    "displayName": "HubSpot Integrations",
+    "description": "Manage HubSpot integration resources."
+  },
+  "mailchimp-integrations": {
+    "displayName": "Mailchimp Integrations",
+    "description": "Manage Mailchimp integration resources."
+  },
+  "sendinblue-integrations": {
+    "displayName": "Sendinblue Integrations",
+    "description": "Manage Sendinblue integration resources."
+  },
+  "notion-workspaces": {
+    "displayName": "Notion Workspaces",
+    "description": "Access Notion workspace connections and related resources."
+  },
+  "social-auth": {
+    "displayName": "Social Auth",
+    "description": "Authenticate or connect users through supported social sign-in flows."
+  },
+  "oembed": {
+    "displayName": "oEmbed",
+    "description": "Resolve oEmbed-compatible representations for supported resources."
+  },
+  "email_verifications": {
+    "displayName": "Email Verifications",
+    "description": "Create and verify email verification flows."
+  },
+  "payment-methods": {
+    "displayName": "Payment Methods",
+    "description": "Manage payment methods used by payment and subscription flows."
+  },
+  "payment-records": {
+    "displayName": "Payment Records",
+    "description": "List and inspect payment records."
+  },
+  "plan-subscriptions": {
+    "displayName": "Plan Subscriptions",
+    "description": "Manage plan subscriptions and subscription state."
+  },
+  "lead-enrichments": {
+    "displayName": "Lead Enrichments",
+    "description": "Access lead enrichment runs and their results."
+  },
+  "reports": {
+    "displayName": "Reports",
+    "description": "Access report generation and report-related resources."
+  },
+  "prompt-categories": {
+    "displayName": "Prompt Categories",
+    "description": "Browse categories used to organize prompts."
+  },
+  "recent-forms": {
+    "displayName": "Recent Forms",
+    "description": "List recently accessed or updated forms."
+  },
+  "recurring-submissions": {
+    "displayName": "Recurring Submissions",
+    "description": "Manage recurring submission resources and schedules."
+  },
+  "row-results": {
+    "displayName": "Row Results",
+    "description": "Access row result resources and related output."
+  },
+  "sync-with-gsheet": {
+    "displayName": "Sync with GSheet",
+    "description": "Manage synchronization flows with Google Sheets."
+  },
+  "two-way-sync": {
+    "displayName": "Two-Way Sync",
+    "description": "Manage bidirectional synchronization resources."
+  },
+  "template-boards": {
+    "displayName": "Template Boards",
+    "description": "Browse and manage reusable template boards."
+  },
+  "user-form-rows": {
+    "displayName": "User Form Rows",
+    "description": "Access rows associated with user form resources."
+  },
+  "user-forms": {
+    "displayName": "User Forms",
+    "description": "Access forms associated with end-user flows."
+  },
+  "themes": {
+    "displayName": "Themes",
+    "description": "Create, copy, and manage reusable theme resources."
+  },
+  "prompts": {
+    "displayName": "Prompts",
+    "description": "Read prompts and prompt-related AI request resources."
+  },
+  "business-engines": {
+    "displayName": "Business Engines",
+    "description": "Manage business engine resources and their configuration."
+  }
+}

--- a/spec/v3.0.yaml
+++ b/spec/v3.0.yaml
@@ -10,9 +10,10 @@ info:
     name: Support
     email: dev@formaloo.com
     url: https://help.formaloo.com/en/
-  externalDocs:
-    description: Find out more
-    url: https://help.formaloo.com/en/
+
+externalDocs:
+  description: Find out more
+  url: https://help.formaloo.com/en/
 
 servers:
   - url: https://api.formaloo.me
@@ -20,7 +21,12 @@ servers:
 
 components:
   securitySchemes:
-    JWT Authentication:
+    ApiKeyAuthentication:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: Application API key required for Formaloo public API requests.
+    JwtAuthentication:
       type: apiKey
       in: header
       name: Authorization

--- a/spec/v3.0.yaml
+++ b/spec/v3.0.yaml
@@ -25,9 +25,9 @@ components:
       type: apiKey
       in: header
       name: x-api-key
-      description: Application API key required for Formaloo public API requests.
+      description: Your API Key from the Formaloo dashboard.
     JwtAuthentication:
       type: apiKey
       in: header
       name: Authorization
-      description: Token-based authentication with required prefix "JWT"
+      description: Use `JWT {Authorization Token}` for protected Formaloo API requests.


### PR DESCRIPTION
## Summary
- refactor the public docs pipeline into fetch, bundle, merge, normalize, validate, and release stages
- add deterministic tooling, validation workflows, release artifacts, and consistent deploy branch resolution
- normalize the published public spec with better tag metadata, schema pruning, baseline error coverage, and clearer auth/header handling
- refresh onboarding and endpoint docs to explain direct API auth, end-user auth flows, workspace-scoped requests, and conditional client-portal headers

## After merge
- merges to `master` will rebuild and redeploy the production public docs with the new normalized public contract
- the published docs will show a clearer external auth model, including direct API key/secret usage and separate end-user auth flows
- generated workflow artifacts will include the final `openapi-v3.0.yaml`, validation reports, and the packaged release bundle on CI runs
- tagged releases will publish the final spec and HTML docs bundle as GitHub release assets

## Verification
- `./generate.sh` (when upstream fetch endpoints respond normally)
- local bundle/merge/normalize/validate pass against downloaded spec inputs
- public contract validation summary reports `0` errors and `0` warnings
- rendered spec now shows:
  - `x-api-key` described as the dashboard API key
  - `Authorization: Basic {API Secret}` on `/v3.0/oauth2/authorization-token/`
  - end-user session-token authorization on `/v1.0/end-users/authorize/`
  - optional `x-app-id` on public form-display submit
  - optional `x-scope` on client-portal auth/profile endpoints

## Notes
- upstream fetches from `api.formaloo.me` were intermittently flaky during review (`curl` HTTP/2 framing / empty reply). The docs pipeline changes themselves were verified by rerunning the post-fetch stages against already-downloaded specs.
- related upstream source-truth fix is open at `formaloo/idealib#6`.
