### PR TITLE
[codex] Publish MCP OpenAPI artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,6 @@ jobs:
         with:
           files: |
             artifacts/release/openapi-v3.0.yaml
+            artifacts/release/openapi-v3.0.mcp.yaml
             artifacts/release/html-docs.tar.gz
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ docker compose up --build
 Generated outputs:
 
 - `openapi-v3.0.yaml`: canonical public OpenAPI artifact
+- `openapi-v3.0.mcp.yaml`: MCP/CLI-oriented artifact mirrored from the backend-published MCP contract
 - `html/`: generated static docs bundle
 - `artifacts/validation/`: validation and lint reports
 - `artifacts/release/`: packaged release assets

--- a/generate.sh
+++ b/generate.sh
@@ -12,6 +12,7 @@ RELEASE_DIR="$ARTIFACTS_DIR/release"
 
 STAGING_DOCS=${STAGING_DOCS:-false}
 PUBLIC_API_URL=${PUBLIC_API_URL:-}
+MCP_OPENAPI_SOURCE=${MCP_OPENAPI_SOURCE:-https://docs.staging.formaloo.com/openapi-v3.0.mcp.yaml}
 
 if [[ -n "${TOOLS_DIR:-}" ]]; then
   TOOL_BIN="$TOOLS_DIR"
@@ -71,19 +72,29 @@ PUBLIC_API_URL="$PUBLIC_API_URL" STAGING_DOCS="$STAGING_DOCS" node "$ROOT_DIR/sc
 echo "Rendering final YAML artifact..."
 "$REDOCLY_BIN" bundle "$INTERMEDIATE_DIR/openapi-public.normalized.json" --output "$ROOT_DIR/openapi-v3.0.yaml"
 
+echo "Fetching MCP OpenAPI artifact..."
+curl --fail --location --retry 3 --retry-all-errors --silent --show-error \
+  "$MCP_OPENAPI_SOURCE" \
+  --output "$ROOT_DIR/openapi-v3.0.mcp.yaml"
+
 echo "Validating generated public contract..."
 node "$ROOT_DIR/scripts/validate-openapi.mjs"
 if ! "$REDOCLY_BIN" lint "$ROOT_DIR/openapi-v3.0.yaml" > "$VALIDATION_DIR/redocly-lint.txt" 2>&1; then
   echo "Redocly lint reported issues. Report saved to artifacts/validation/redocly-lint.txt"
 fi
+if ! "$REDOCLY_BIN" lint "$ROOT_DIR/openapi-v3.0.mcp.yaml" > "$VALIDATION_DIR/redocly-mcp-lint.txt" 2>&1; then
+  echo "Redocly lint reported MCP issues. Report saved to artifacts/validation/redocly-mcp-lint.txt"
+fi
 
 echo "Building HTML documentation..."
 "$REDOCLY_BIN" build-docs "$ROOT_DIR/openapi-v3.0.yaml" -o "$HTML_DIR/index.html"
 cp "$ROOT_DIR/openapi-v3.0.yaml" "$HTML_DIR/openapi-v3.0.yaml"
+cp "$ROOT_DIR/openapi-v3.0.mcp.yaml" "$HTML_DIR/openapi-v3.0.mcp.yaml"
 cp -r "$ROOT_DIR/assets" "$HTML_DIR/"
 
 echo "Packaging release artifacts..."
 cp "$ROOT_DIR/openapi-v3.0.yaml" "$RELEASE_DIR/openapi-v3.0.yaml"
+cp "$ROOT_DIR/openapi-v3.0.mcp.yaml" "$RELEASE_DIR/openapi-v3.0.mcp.yaml"
 tar -czf "$RELEASE_DIR/html-docs.tar.gz" -C "$ROOT_DIR" html
 
 echo "Build complete."


### PR DESCRIPTION
## Summary

- Fetch the backend-published MCP artifact during documentation generation.
- Validate and deploy it alongside the public OpenAPI artifact.
- Attach it to documentation releases.

## Validation

- `npm run build:docs`
- Redocly validation of `openapi-v3.0.mcp.yaml`
