### PR TITLE
docs(openapi): clarify MCP API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ STAGING_DOCS=true ./generate.sh
 
 Documentation consists of automated OpenAPI specs from services, a public normalization step, and manual descriptions added in this repository.
 
+### Branch and Deployment Flow
+
+This repository uses both `dev` and `master` in the documentation release flow:
+
+- `dev` is the staging documentation branch.
+- `master` is the production documentation branch.
+- Changes may be merged between `dev` and `master` as part of promotion or backfill work.
+
+Target `dev` first for new documentation or generated-spec improvements unless the change is explicitly production-only. Check both branches before repeating work, because staging may contain changes that are not yet in production.
+
+### MCP-Focused OpenAPI Guidance
+
+The MCP artifact (`openapi-v3.0.mcp.yaml`) should stay accurate for direct API users and easy to use for MCP/CLI clients:
+
+- Keep required API headers documented when the underlying API requires them. For example, `x-api-key` is required for direct Formaloo API calls and should remain visible in the spec.
+- When a hosted MCP server or CLI has a configured Formaloo API key, the client should inject that configured value instead of asking the user or agent to provide `x-api-key` for each tool call.
+- Describe product terminology in user-facing language first, then mention legacy API terms where needed. For example, use “workspace” first and explain that API paths may still use “business”.
+- For high-value MCP operations, include clear summaries, examples, result paths, pagination notes, and `x-formaloo-mcp` metadata so agents can choose the right operation without guessing from raw operation IDs.
+
 ### Adding Manual Descriptions
 
 Manual descriptions are stored as Markdown files matching the endpoint path and HTTP method. For example, the endpoint `PATCH /v3.0/forms/{slug}/` uses:

--- a/scripts/build-mcp-openapi.mjs
+++ b/scripts/build-mcp-openapi.mjs
@@ -778,6 +778,30 @@ const localDescriptionFixes = {
   }
 };
 
+const mcpApiKeyHeaderDescription = [
+  "Formaloo API key.",
+  "Required for direct Formaloo API calls.",
+  "Hosted MCP servers and CLI clients should supply this from their configured credentials instead of asking the user or agent to pass it on each request."
+].join(" ");
+
+function buildMcpAuthMetadata(mcpMetadata) {
+  return {
+    api_key: {
+      required: true,
+      header: "x-api-key",
+      direct_api_usage: "Callers must send a valid Formaloo API key.",
+      mcp_cli_usage:
+        "Hosted MCP servers and CLI clients should inject a configured API key; do not model it as a natural-language task argument."
+    },
+    workspace: {
+      required: Boolean(mcpMetadata?.requires_workspace),
+      header: "x-workspace",
+      usage:
+        "Workspace selector for workspace-scoped requests. Use list_workspaces or the businesses endpoints to discover the correct workspace slug."
+    }
+  };
+}
+
 function setResponseExamples(operation, examplesByStatus) {
   for (const [statusCode, examples] of Object.entries(examplesByStatus ?? {})) {
     const response = operation.responses?.[statusCode];
@@ -825,6 +849,53 @@ function applyParameterDescriptions(operation, descriptions = {}) {
   }
 }
 
+function updateApiKeyHeaderParameter(openapiSpec, parameter) {
+  if (!parameter || typeof parameter !== "object") {
+    return;
+  }
+
+  let target = parameter;
+  if (typeof parameter.$ref === "string") {
+    target = getRefTarget(openapiSpec, parameter.$ref);
+  }
+
+  if (
+    target?.in === "header" &&
+    typeof target.name === "string" &&
+    target.name.toLowerCase() === "x-api-key"
+  ) {
+    target.description = mcpApiKeyHeaderDescription;
+    target.required = true;
+  }
+}
+
+function updateApiKeyHeaderDescriptions(openapiSpec) {
+  for (const pathItem of Object.values(openapiSpec.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== "object") {
+      continue;
+    }
+
+    for (const parameter of pathItem.parameters ?? []) {
+      updateApiKeyHeaderParameter(openapiSpec, parameter);
+    }
+
+    for (const method of httpMethods) {
+      const operation = pathItem[method];
+      if (!operation || typeof operation !== "object") {
+        continue;
+      }
+
+      for (const parameter of operation.parameters ?? []) {
+        updateApiKeyHeaderParameter(openapiSpec, parameter);
+      }
+    }
+  }
+
+  for (const parameter of Object.values(openapiSpec.components?.parameters ?? {})) {
+    updateApiKeyHeaderParameter(openapiSpec, parameter);
+  }
+}
+
 function enrichMcpOperations(openapiSpec) {
   for (const pathItem of Object.values(openapiSpec.paths ?? {})) {
     if (!pathItem || typeof pathItem !== "object") {
@@ -841,7 +912,10 @@ function enrichMcpOperations(openapiSpec) {
       if (coreDefinition) {
         operation.summary = coreDefinition.summary;
         operation.description = coreDefinition.description;
-        operation["x-formaloo-mcp"] = coreDefinition.mcp;
+        operation["x-formaloo-mcp"] = {
+          ...coreDefinition.mcp,
+          auth: buildMcpAuthMetadata(coreDefinition.mcp)
+        };
         applyParameterDescriptions(operation, coreDefinition.parameterDescriptions);
         setRequestExamples(operation, coreDefinition.requestExamples);
         setResponseExamples(operation, coreDefinition.responseExamples);
@@ -895,6 +969,7 @@ for (const [pathKey, pathItem] of Object.entries(spec.paths ?? {})) {
 spec.paths = filteredPaths;
 spec.tags = (spec.tags ?? []).filter((tag) => typeof tag?.name === "string" && usedTagNames.has(tag.name));
 relaxWorkspaceHeaderRequirements(spec);
+updateApiKeyHeaderDescriptions(spec);
 enrichMcpOperations(spec);
 
 await fs.mkdir(intermediateDir, { recursive: true });


### PR DESCRIPTION
## Summary

- documents the API docs repo branch flow: dev for staging, master for production
- clarifies that x-api-key remains required for direct Formaloo API calls
- adds MCP-specific auth guidance so hosted MCP/CLI clients can inject configured API credentials instead of treating x-api-key as a per-tool user argument
- adds the same auth guidance into x-formaloo-mcp metadata for the existing core MCP operations

## Validation

- npm ci
- STAGING_DOCS=true ./generate.sh
- git diff --check

Generated MCP and public spec validation completed with no errors or warnings.