### PR TITLE
docs(openapi): document field creation contracts

### DIFF
--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -1411,7 +1411,7 @@ function enrichFieldCreateSchemasAndOperations() {
       )
     },
     description:
-      "Generic field creation payload. Use `type` to choose the field kind and `sub_type` when the field kind has variants. This schema reuses the same field-specific request schemas as the per-type field creation endpoints."
+      "Generic field creation payload for documented, schema-backed field types. Use `type` to choose the field kind and `sub_type` when the field kind has variants. This schema reuses the same field-specific request schemas as the per-type field creation endpoints; dashboard-only shortcuts and special flows may require additional defaults not represented here."
   };
 
   const fieldsCreate = spec.paths["/v3.0/fields/"]?.post;
@@ -1419,7 +1419,7 @@ function enrichFieldCreateSchemasAndOperations() {
     upsertJsonRequestBody(fieldsCreate, "#/components/schemas/FormalooFieldCreateRequest", true);
     setOperationDescription(
       fieldsCreate,
-      "Recommended field creation endpoint for agents and form builders. It accepts all supported field types through one URL. Prefer this endpoint when adding mixed field types programmatically; use `type` and, where needed, `sub_type` to select the exact field variant. The per-type endpoints document the same field-specific settings and remain available as specialized alternatives."
+      "Recommended field creation endpoint for agents and form builders when adding documented, schema-backed field types through one URL. Prefer this endpoint when adding mixed field types programmatically; use `type` and, where needed, `sub_type` to select the exact field variant. The per-type endpoints document the same field-specific settings and remain available as specialized alternatives. Some dashboard editor shortcuts and special fields apply extra UI defaults or use contracts that are not yet fully represented in the generated OpenAPI schema."
     );
     setJsonExamples(fieldsCreate, {
       short_text: {

--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -1089,6 +1089,484 @@ function enrichFormBuilderSchemasAndOperations() {
   }
 }
 
+function createTypedFieldSchema({ schemaName, type, description, subType, notes }) {
+  const properties = {
+    type: {
+      type: "string",
+      enum: [type],
+      description: `Field type discriminator. Must be \`${type}\` for this payload shape.`
+    }
+  };
+  const required = ["type"];
+
+  if (subType) {
+    properties.sub_type = {
+      type: "string",
+      enum: subType.values,
+      ...(subType.default ? { default: subType.default } : {}),
+      description: subType.description
+    };
+  }
+
+  return {
+    allOf: [
+      { $ref: `#/components/schemas/${schemaName}` },
+      {
+        type: "object",
+        additionalProperties: true,
+        description: notes ? `${description} ${notes}` : description,
+        required,
+        properties
+      }
+    ]
+  };
+}
+
+function setOperationDescription(operation, description) {
+  if (!operation) {
+    return;
+  }
+
+  const existing = typeof operation.description === "string" ? operation.description.trim() : "";
+  operation.description = existing ? `${existing}\n\n${description}` : description;
+}
+
+function setJsonExamples(operation, examples) {
+  if (!operation?.requestBody?.content) {
+    return;
+  }
+
+  for (const mediaType of Object.keys(operation.requestBody.content)) {
+    const content = operation.requestBody.content[mediaType];
+    if (!content || typeof content !== "object") {
+      continue;
+    }
+    content.examples = {
+      ...(content.examples ?? {}),
+      ...examples
+    };
+  }
+}
+
+function enrichFieldCreateSchemasAndOperations() {
+  const fieldCreateVariants = [
+    {
+      componentName: "FormalooShortTextFieldCreate",
+      schemaName: "CharFieldRequest",
+      type: "short_text",
+      description: "Creates a short text field for single-line text answers."
+    },
+    {
+      componentName: "FormalooLongTextFieldCreate",
+      schemaName: "TextFieldRequest",
+      type: "long_text",
+      description: "Creates a long text field for multi-line text answers."
+    },
+    {
+      componentName: "FormalooRegexFieldCreate",
+      schemaName: "CharFieldRequest",
+      type: "regex",
+      description: "Creates a custom-validation text field. Include regex settings accepted by the field API."
+    },
+    {
+      componentName: "FormalooEmailFieldCreate",
+      schemaName: "EmailFieldRequest",
+      type: "email",
+      description: "Creates an email field."
+    },
+    {
+      componentName: "FormalooPhoneFieldCreate",
+      schemaName: "PhoneFieldRequest",
+      type: "phone",
+      description: "Creates a phone-number field."
+    },
+    {
+      componentName: "FormalooWebsiteFieldCreate",
+      schemaName: "WebsiteFieldRequest",
+      type: "website",
+      description: "Creates a website/URL field."
+    },
+    {
+      componentName: "FormalooNumberFieldCreate",
+      schemaName: "NumberFieldRequest",
+      type: "number",
+      description:
+        "Creates a number field. Use min_value, max_value, and decimal_places for numeric constraints."
+    },
+    {
+      componentName: "FormalooDateFieldCreate",
+      schemaName: "DateFieldRequest",
+      type: "date",
+      description:
+        "Creates a date field. Use fixed from_date/to_date or relative_range_start/relative_range_end when constraining answers."
+    },
+    {
+      componentName: "FormalooDateTimeFieldCreate",
+      schemaName: "DateTimeFieldRequest",
+      type: "datetime",
+      description: "Creates a date-time field."
+    },
+    {
+      componentName: "FormalooTimeFieldCreate",
+      schemaName: "TimeFieldRequest",
+      type: "time",
+      description: "Creates a time field."
+    },
+    {
+      componentName: "FormalooCheckboxFieldCreate",
+      schemaName: "BooleanFieldRequest",
+      type: "checkbox",
+      description: "Creates a required-style checkbox field with a yes/no value."
+    },
+    {
+      componentName: "FormalooYesNoFieldCreate",
+      schemaName: "YesNoFieldRequest",
+      type: "yes_no",
+      description: "Creates a yes/no field."
+    },
+    {
+      componentName: "FormalooChoiceFieldCreate",
+      schemaName: "ChoiceFieldRequest",
+      type: "choice",
+      description:
+        "Creates a single-choice field. Provide choices with choice_items or bulk_choices, but not both."
+    },
+    {
+      componentName: "FormalooDropdownFieldCreate",
+      schemaName: "DropdownFieldRequest",
+      type: "dropdown",
+      description:
+        "Creates a single-select dropdown field. Provide choices with choice_items or bulk_choices, but not both."
+    },
+    {
+      componentName: "FormalooMultipleSelectFieldCreate",
+      schemaName: "MultipleSelectFieldRequest",
+      type: "multiple_select",
+      description:
+        "Creates a multiple-select field. Use sub_type to choose standard multi-choice, dropdown multi-choice, or ranking.",
+      subType: {
+        values: ["standard", "dropdown", "ranking"],
+        default: "standard",
+        description:
+          "`standard` renders as normal multiple choice, `dropdown` renders as a multiple-choice dropdown, and `ranking` renders as a ranking field."
+      }
+    },
+    {
+      componentName: "FormalooRatingFieldCreate",
+      schemaName: "RatingFieldRequest",
+      type: "rating",
+      description:
+        "Creates a rating field. Use sub_type to choose Star Rating/CSAT, Like/Dislike, NPS, or Slider.",
+      subType: {
+        values: ["embeded", "like_dislike", "nps", "score"],
+        default: "embeded",
+        description:
+          "`embeded` is the dashboard-compatible Star Rating / CSAT subtype. The spelling is legacy API spelling. Use `nps` for NPS, `score` for slider, and `like_dislike` for thumbs up/down. Some older/generated contracts may mention `star`; treat it as a legacy alias and prefer `embeded` for new fields."
+      }
+    },
+    {
+      componentName: "FormalooFileFieldCreate",
+      schemaName: "FileFieldRequest",
+      type: "file",
+      description: "Creates a file-upload field."
+    },
+    {
+      componentName: "FormalooSignatureFieldCreate",
+      schemaName: "SignatureFieldRequest",
+      type: "signature",
+      description: "Creates a signature field."
+    },
+    {
+      componentName: "FormalooMatrixFieldCreate",
+      schemaName: "MatrixFieldRequest",
+      type: "matrix",
+      description:
+        "Creates a matrix field. Use choice_groups for rows and choice_items for selectable options."
+    },
+    {
+      componentName: "FormalooMetaFieldCreate",
+      schemaName: "MetaFieldRequest",
+      type: "meta",
+      description: "Creates a content/meta field such as page break, section text, or video.",
+      subType: {
+        values: ["page_break", "section", "video"],
+        description:
+          "`page_break` divides a form into pages, `section` adds static content, and `video` embeds video content."
+      }
+    },
+    {
+      componentName: "FormalooOembedFieldCreate",
+      schemaName: "OembedFieldRequest",
+      type: "oembed",
+      description: "Creates an oEmbed field for external embedded content."
+    },
+    {
+      componentName: "FormalooHiddenFieldCreate",
+      schemaName: "HiddenFieldRequest",
+      type: "hidden",
+      description: "Creates a hidden field."
+    },
+    {
+      componentName: "FormalooVariableFieldCreate",
+      schemaName: "VariableFieldRequest",
+      type: "variable",
+      description: "Creates a logic/calculation variable field.",
+      subType: {
+        values: ["int", "decimal", "string", "formula"],
+        default: "int",
+        description:
+          "`int` and `decimal` are numeric variables, `string` is a text variable, and `formula` is calculated from a formula expression."
+      }
+    },
+    {
+      componentName: "FormalooProductFieldCreate",
+      schemaName: "ProductFieldRequest",
+      type: "product",
+      description: "Creates a product/payment field."
+    },
+    {
+      componentName: "FormalooLookupFieldCreate",
+      schemaName: "LookupFieldRequest",
+      type: "lookup",
+      description: "Creates a lookup field connected to linked rows or another related source."
+    },
+    {
+      componentName: "FormalooLinkedRowsFieldCreate",
+      schemaName: "LinkedRowsFieldRequest",
+      type: "linked_rows",
+      description: "Creates a linked-rows field that links this form to records in another form."
+    },
+    {
+      componentName: "FormalooRepeatingSectionFieldCreate",
+      schemaName: "RepeatingSectionFieldRequest",
+      type: "repeating_section",
+      description: "Creates a repeating section field."
+    },
+    {
+      componentName: "FormalooProfileFieldCreate",
+      schemaName: "ProfileFieldRequest",
+      type: "profile",
+      description: "Creates a profile field for portal/user-associated records."
+    },
+    {
+      componentName: "FormalooProfileDataFieldCreate",
+      schemaName: "ProfileDataFieldRequest",
+      type: "profile_data",
+      description: "Creates a profile-data field connected to a profile field."
+    },
+    {
+      componentName: "FormalooAssigneeFieldCreate",
+      schemaName: "AssigneeFieldRequest",
+      type: "assignee",
+      description: "Creates an assignee field."
+    },
+    {
+      componentName: "FormalooAIBoxFieldCreate",
+      schemaName: "AIBoxFieldRequest",
+      type: "ai_box",
+      description:
+        "Creates an AI Analysis field. Dashboard-created AI Analysis fields are admin-only and store output on the row."
+    },
+    {
+      componentName: "FormalooCountryFieldCreate",
+      schemaName: "CountryFieldRequest",
+      type: "country",
+      description: "Creates a country field."
+    },
+    {
+      componentName: "FormalooCityFieldCreate",
+      schemaName: "CityFieldRequest",
+      type: "city",
+      description: "Creates a city field."
+    },
+    {
+      componentName: "FormalooUserFieldCreate",
+      schemaName: "UserFieldRequest",
+      type: "user",
+      description: "Creates a user field."
+    },
+    {
+      componentName: "FormalooSuccessPageFieldCreate",
+      schemaName: "SuccessPageFieldRequest",
+      type: "success_page",
+      description: "Creates a success-page field."
+    }
+  ].filter(({ schemaName }) => spec.components.schemas[schemaName]);
+
+  for (const variant of fieldCreateVariants) {
+    spec.components.schemas[variant.componentName] = createTypedFieldSchema(variant);
+  }
+
+  spec.components.schemas.FormalooFieldCreateRequest = {
+    oneOf: fieldCreateVariants.map(({ componentName }) => ({
+      $ref: `#/components/schemas/${componentName}`
+    })),
+    discriminator: {
+      propertyName: "type",
+      mapping: Object.fromEntries(
+        fieldCreateVariants.map(({ type, componentName }) => [
+          type,
+          `#/components/schemas/${componentName}`
+        ])
+      )
+    },
+    description:
+      "Generic field creation payload. Use `type` to choose the field kind and `sub_type` when the field kind has variants. This schema reuses the same field-specific request schemas as the per-type field creation endpoints."
+  };
+
+  const fieldsCreate = spec.paths["/v3.0/fields/"]?.post;
+  if (fieldsCreate) {
+    upsertJsonRequestBody(fieldsCreate, "#/components/schemas/FormalooFieldCreateRequest", true);
+    setOperationDescription(
+      fieldsCreate,
+      "Recommended field creation endpoint for agents and form builders. It accepts all supported field types through one URL. Prefer this endpoint when adding mixed field types programmatically; use `type` and, where needed, `sub_type` to select the exact field variant. The per-type endpoints document the same field-specific settings and remain available as specialized alternatives."
+    );
+    setJsonExamples(fieldsCreate, {
+      short_text: {
+        summary: "Short text field",
+        value: {
+          form: "customer-feedback",
+          title: "Full name",
+          type: "short_text",
+          required: true
+        }
+      },
+      star_rating_csat: {
+        summary: "Star Rating / CSAT field",
+        value: {
+          form: "customer-feedback",
+          title: "How satisfied are you?",
+          type: "rating",
+          sub_type: "embeded",
+          range_start: 1,
+          range_end: 5
+        }
+      },
+      nps_rating: {
+        summary: "NPS field",
+        value: {
+          form: "customer-feedback",
+          title: "How likely are you to recommend us?",
+          type: "rating",
+          sub_type: "nps",
+          range_start: 0,
+          range_end: 10
+        }
+      },
+      multiple_choice: {
+        summary: "Multiple choice field",
+        value: {
+          form: "customer-feedback",
+          title: "Which products do you use?",
+          type: "multiple_select",
+          sub_type: "standard",
+          choice_items: [{ title: "Forms" }, { title: "Portals" }, { title: "Workflows" }]
+        }
+      },
+      ranking: {
+        summary: "Ranking field",
+        value: {
+          form: "customer-feedback",
+          title: "Rank these priorities",
+          type: "multiple_select",
+          sub_type: "ranking",
+          choice_items: [{ title: "Speed" }, { title: "Price" }, { title: "Support" }]
+        }
+      },
+      page_break: {
+        summary: "Page break",
+        value: {
+          form: "customer-feedback",
+          title: "Next section",
+          type: "meta",
+          sub_type: "page_break"
+        }
+      },
+      variable: {
+        summary: "Numeric variable",
+        value: {
+          form: "customer-feedback",
+          title: "Lead score",
+          type: "variable",
+          sub_type: "int",
+          admin_only: true
+        }
+      }
+    });
+  }
+
+  const perTypeExamples = {
+    fieldsRatingCreate: {
+      star_rating_csat: {
+        summary: "Star Rating / CSAT field",
+        value: {
+          form: "customer-feedback",
+          title: "How satisfied are you?",
+          sub_type: "embeded",
+          range_start: 1,
+          range_end: 5
+        }
+      }
+    },
+    fieldsMultipleSelectCreate: {
+      ranking: {
+        summary: "Ranking field",
+        value: {
+          form: "customer-feedback",
+          title: "Rank these priorities",
+          sub_type: "ranking",
+          choice_items: [{ title: "Speed" }, { title: "Price" }, { title: "Support" }]
+        }
+      }
+    },
+    fieldsMetaCreate: {
+      page_break: {
+        summary: "Page break",
+        value: {
+          form: "customer-feedback",
+          title: "Next section",
+          sub_type: "page_break"
+        }
+      }
+    },
+    fieldsVariableCreate: {
+      numeric_variable: {
+        summary: "Numeric variable",
+        value: {
+          form: "customer-feedback",
+          title: "Lead score",
+          sub_type: "int",
+          admin_only: true
+        }
+      }
+    }
+  };
+
+  for (const pathItem of Object.values(spec.paths ?? {})) {
+    for (const operation of Object.values(pathItem ?? {})) {
+      if (!operation || typeof operation !== "object") {
+        continue;
+      }
+      const examples = perTypeExamples[operation.operationId];
+      if (examples) {
+        setJsonExamples(operation, examples);
+      }
+      if (operation.operationId === "fieldsRatingCreate") {
+        setOperationDescription(
+          operation,
+          "For dashboard-compatible Star Rating / CSAT fields, use `sub_type: \"embeded\"` (legacy API spelling). Use `nps` for NPS, `score` for slider, and `like_dislike` for thumbs up/down."
+        );
+      }
+      if (operation.operationId === "fieldsMultipleSelectCreate") {
+        setOperationDescription(
+          operation,
+          "Use `sub_type: \"standard\"` for normal multiple choice, `dropdown` for multiple-choice dropdown, and `ranking` for ranking fields."
+        );
+      }
+    }
+  }
+}
+
 function enrichBoardDeleteOperation() {
   spec.components.schemas.BoardDeleteRequest = {
     type: "object",
@@ -1139,18 +1617,51 @@ function enrichChoiceFieldSchemas() {
     }
 
     if (schema.properties.choice_items) {
-      schema.properties.choice_items.description =
-        schema.properties.choice_items.description ?? choiceInputDescription;
-      if (schema.properties.choice_items.type === "array" && !schema.properties.choice_items.items) {
-        schema.properties.choice_items.items = {
-          $ref: "#/components/schemas/FormalooBuilderChoiceInput"
-        };
-      }
+      schema.properties.choice_items = {
+        ...schema.properties.choice_items,
+        oneOf: [
+          {
+            type: "array",
+            items: { $ref: "#/components/schemas/FormalooBuilderChoiceInput" }
+          },
+          {
+            type: "object",
+            additionalProperties: true,
+            description:
+              "Legacy object shape accepted by some generated contracts. Prefer an array of choice objects for new integrations."
+          }
+        ],
+        description: schema.properties.choice_items.description ?? choiceInputDescription
+      };
+      delete schema.properties.choice_items.type;
+      delete schema.properties.choice_items.items;
+      delete schema.properties.choice_items.nullable;
     }
 
     if (schema.properties.bulk_choices) {
-      schema.properties.bulk_choices.description =
-        schema.properties.bulk_choices.description ?? bulkChoicesDescription;
+      schema.properties.bulk_choices = {
+        ...schema.properties.bulk_choices,
+        oneOf: [
+          {
+            type: "array",
+            items: { type: "string" },
+            description: "List of choice labels to add."
+          },
+          {
+            type: "string",
+            description: "Newline-separated choice labels to add."
+          },
+          {
+            type: "object",
+            additionalProperties: true,
+            description:
+              "Legacy object shape accepted by some generated contracts. Prefer an array or newline-separated string for new integrations."
+          }
+        ],
+        description: schema.properties.bulk_choices.description ?? bulkChoicesDescription
+      };
+      delete schema.properties.bulk_choices.type;
+      delete schema.properties.bulk_choices.nullable;
     }
   }
 }
@@ -1297,6 +1808,7 @@ enrichFormLogicSchemas();
 enrichThemeSchemas();
 enrichThemeOperations();
 enrichFormBuilderSchemasAndOperations();
+enrichFieldCreateSchemasAndOperations();
 enrichBoardDeleteOperation();
 enrichChoiceFieldSchemas();
 normalizeSchemaTree(spec.components?.schemas);

--- a/spec/docs/v3.0/fields/meta/post.md
+++ b/spec/docs/v3.0/fields/meta/post.md
@@ -1,1 +1,9 @@
-Creates a non-answer content field such as headings, descriptions, media, or other layout content. Use this when adding instructional or visual content to a form rather than collecting respondent input.
+Creates a non-answer content field such as headings, descriptions, media, page breaks, or other layout content. Use this when adding instructional or visual content to a form rather than collecting respondent input.
+
+Supported `sub_type` values:
+
+| Content variant | `sub_type` |
+| --- | --- |
+| Page break | `page_break` |
+| Section/content | `section` |
+| Video | `video` |

--- a/spec/docs/v3.0/fields/multiple_select/post.md
+++ b/spec/docs/v3.0/fields/multiple_select/post.md
@@ -1,8 +1,31 @@
 Creates a multiple-select field. Use this when respondents can choose more than one option from a fixed list.
 
+Supported `sub_type` values:
+
+| Field variant | `sub_type` |
+| --- | --- |
+| Multiple choice | `standard` |
+| Multiple choice dropdown | `dropdown` |
+| Ranking | `ranking` |
+
 Choices can be supplied in either of two ways:
 
 - `choice_items`: explicit choice objects, for example `{ "title": "Enterprise" }`.
 - `bulk_choices`: a list of labels or a newline-separated string.
 
 Do not send `choice_items` and `bulk_choices` in the same request. When submitting or updating rows, multiple-select values should be sent as a list of choice slugs.
+
+Example ranking field:
+
+```json
+{
+  "form": "customer-feedback",
+  "title": "Rank these priorities",
+  "sub_type": "ranking",
+  "choice_items": [
+    { "title": "Speed" },
+    { "title": "Price" },
+    { "title": "Support" }
+  ]
+}
+```

--- a/spec/docs/v3.0/fields/post.md
+++ b/spec/docs/v3.0/fields/post.md
@@ -1,1 +1,27 @@
-Creates a form field using the type supplied in the request body. Use this generic field creation endpoint when an agent is programmatically adding mixed field types and wants one URL for the form builder workflow.
+Creates a form field using the `type` supplied in the request body. This is the recommended endpoint for agents, CLI clients, and form builders that programmatically add mixed field types through one URL.
+
+Use the `type` field to choose the field kind, and use `sub_type` only for field families that have variants.
+
+Common examples:
+
+| Field | `type` | `sub_type` |
+| --- | --- | --- |
+| Short text | `short_text` | — |
+| Long text | `long_text` | — |
+| Single choice | `choice` | — |
+| Dropdown | `dropdown` | — |
+| Multiple choice | `multiple_select` | `standard` |
+| Multiple choice dropdown | `multiple_select` | `dropdown` |
+| Ranking | `multiple_select` | `ranking` |
+| Star Rating / CSAT | `rating` | `embeded` |
+| Like/Dislike | `rating` | `like_dislike` |
+| NPS | `rating` | `nps` |
+| Slider | `rating` | `score` |
+| Page break | `meta` | `page_break` |
+| Section/content | `meta` | `section` |
+| Video content | `meta` | `video` |
+| Variable | `variable` | `int`, `decimal`, `string`, or `formula` |
+
+`embeded` is the legacy API spelling used for dashboard-compatible Star Rating / CSAT fields. Some generated contracts may also show `star`; prefer `embeded` for new fields that should edit cleanly in the dashboard.
+
+For choice-like fields, provide choices with either `choice_items` or `bulk_choices`, but not both. See the per-type field endpoints for the field-specific settings reused by this generic endpoint.

--- a/spec/docs/v3.0/fields/post.md
+++ b/spec/docs/v3.0/fields/post.md
@@ -1,4 +1,4 @@
-Creates a form field using the `type` supplied in the request body. This is the recommended endpoint for agents, CLI clients, and form builders that programmatically add mixed field types through one URL.
+Creates a form field using the `type` supplied in the request body. This is the recommended endpoint for agents, CLI clients, and form builders that programmatically add documented, schema-backed field types through one URL.
 
 Use the `type` field to choose the field kind, and use `sub_type` only for field families that have variants.
 
@@ -25,3 +25,5 @@ Common examples:
 `embeded` is the legacy API spelling used for dashboard-compatible Star Rating / CSAT fields. Some generated contracts may also show `star`; prefer `embeded` for new fields that should edit cleanly in the dashboard.
 
 For choice-like fields, provide choices with either `choice_items` or `bulk_choices`, but not both. See the per-type field endpoints for the field-specific settings reused by this generic endpoint.
+
+Some dashboard editor items are shortcuts or special flows rather than distinct simple field contracts. For example, Contact Info creates multiple normal fields, Terms and Conditions and Review apply generated defaults, and some special fields may require additional contracts that are not yet fully represented in the generated OpenAPI schema.

--- a/spec/docs/v3.0/fields/rating/post.md
+++ b/spec/docs/v3.0/fields/rating/post.md
@@ -1,1 +1,24 @@
-Creates a rating field. Use this for satisfaction scores, review scales, NPS-like questions, or other ranked feedback.
+Creates a rating field. Use this for satisfaction scores, review scales, NPS questions, sliders, or thumbs up/down feedback.
+
+Supported `sub_type` values:
+
+| Rating variant | `sub_type` | Notes |
+| --- | --- | --- |
+| Star Rating / CSAT | `embeded` | Dashboard-compatible value. The spelling is legacy API spelling. |
+| Like/Dislike | `like_dislike` | Thumbs up/down style rating. |
+| NPS | `nps` | Usually used with `range_start: 0` and `range_end: 10`. |
+| Slider | `score` | Slider-style score input. |
+
+Some older/generated contracts may mention `star`; treat it as a legacy alias and use `embeded` for new dashboard-editable Star Rating / CSAT fields.
+
+Example Star Rating / CSAT field:
+
+```json
+{
+  "form": "customer-feedback",
+  "title": "How satisfied are you?",
+  "sub_type": "embeded",
+  "range_start": 1,
+  "range_end": 5
+}
+```

--- a/spec/docs/v3.0/fields/variable/post.md
+++ b/spec/docs/v3.0/fields/variable/post.md
@@ -1,1 +1,10 @@
 Creates a variable field used for internal values, calculations, logic, scoring, or pricing. Use this when a form needs state that participates in rules but is not a normal respondent input.
+
+Supported `sub_type` values:
+
+| Variable variant | `sub_type` |
+| --- | --- |
+| Integer number | `int` |
+| Decimal number | `decimal` |
+| Text/string | `string` |
+| Formula | `formula` |


### PR DESCRIPTION
## Summary

- add a polymorphic `FormalooFieldCreateRequest` schema for generic `POST /v3.0/fields/`
- document common field `type` / `sub_type` pairs, including dashboard-compatible rating, multiple-select, meta, and variable variants
- add examples for generic field creation and key per-type field creation endpoints
- accept choice inputs as arrays/newline strings in docs where dashboard/client usage relies on them

## Notes

- Base branch is `dev`, matching the API docs staging flow.
- Star Rating / CSAT uses `sub_type: "embeded"` because that is the legacy API spelling used by dashboard/form-ui. `star` is mentioned only as a legacy/generated-contract alias, not as the recommended value.
- The generic field endpoint is documented as the recommended programmatic entrypoint; per-type endpoints remain useful as detailed reference points for type-specific fields.

## Validation

- `./generate.sh`
- generated public contract: no errors, no warnings
- generated MCP contract: no errors, no warnings
- Redocly validation: valid
