### PR TITLE
docs(fields): cover form editor field contracts

### DIFF
--- a/scripts/normalize-openapi.mjs
+++ b/scripts/normalize-openapi.mjs
@@ -1122,6 +1122,68 @@ function createTypedFieldSchema({ schemaName, type, description, subType, notes 
   };
 }
 
+function createManualTypedFieldSchema({ type, description }) {
+  return {
+    type: "object",
+    additionalProperties: true,
+    description,
+    required: ["type"],
+    properties: {
+      form: {
+        type: "string",
+        nullable: true,
+        description: "Slug of the form to which this field will be added."
+      },
+      repeating_section: {
+        type: "string",
+        nullable: true,
+        description: "Slug of the repeating section field to which this field will be added."
+      },
+      beforeFieldRefId: {
+        type: "string",
+        nullable: true,
+        description: "Optional field ref_id used to insert the new field before an existing field."
+      },
+      type: {
+        type: "string",
+        enum: [type],
+        description: `Field type discriminator. Must be \`${type}\` for this payload shape.`
+      },
+      title: {
+        type: "string",
+        nullable: true,
+        description: "Field title or label shown to users."
+      },
+      description: {
+        type: "string",
+        nullable: true,
+        description: "Optional help text or rich text shown with the field."
+      },
+      alias: {
+        type: "string",
+        nullable: true,
+        description: "Optional user-defined field alias, unique within the form when set."
+      },
+      required: {
+        type: "boolean",
+        description: "Whether the field must be answered by submitters."
+      },
+      admin_only: {
+        type: "boolean",
+        description: "Whether the field is visible only to admins and hidden from submitters."
+      },
+      invisible: {
+        type: "boolean",
+        description: "Whether the field is hidden from the public form view."
+      },
+      read_only: {
+        type: "boolean",
+        description: "Whether submitters can view but not edit the field."
+      }
+    }
+  };
+}
+
 function setOperationDescription(operation, description) {
   if (!operation) {
     return;
@@ -1343,6 +1405,13 @@ function enrichFieldCreateSchemasAndOperations() {
       description: "Creates a repeating section field."
     },
     {
+      componentName: "FormalooTableFieldCreate",
+      manualSchema: true,
+      type: "table",
+      description:
+        "Creates a table field for collecting multiple rows of structured data. This field type is available in the dashboard form editor; the backend-generated OpenAPI currently exposes the `table` enum value but not a dedicated request schema, so this generic schema documents the verified create shape and leaves field-specific table configuration as additional properties."
+    },
+    {
       componentName: "FormalooProfileFieldCreate",
       schemaName: "ProfileFieldRequest",
       type: "profile",
@@ -1380,6 +1449,13 @@ function enrichFieldCreateSchemasAndOperations() {
       description: "Creates a city field."
     },
     {
+      componentName: "FormalooEmailVerificationFieldCreate",
+      manualSchema: true,
+      type: "email_verification",
+      description:
+        "Creates an email verification field that verifies the submitter's email by OTP. This field type is available in the dashboard form editor; the backend-generated OpenAPI currently exposes the `email_verification` enum value but not a dedicated request schema, so this generic schema documents the verified create shape."
+    },
+    {
       componentName: "FormalooUserFieldCreate",
       schemaName: "UserFieldRequest",
       type: "user",
@@ -1391,10 +1467,12 @@ function enrichFieldCreateSchemasAndOperations() {
       type: "success_page",
       description: "Creates a success-page field."
     }
-  ].filter(({ schemaName }) => spec.components.schemas[schemaName]);
+  ].filter(({ schemaName, manualSchema }) => manualSchema || spec.components.schemas[schemaName]);
 
   for (const variant of fieldCreateVariants) {
-    spec.components.schemas[variant.componentName] = createTypedFieldSchema(variant);
+    spec.components.schemas[variant.componentName] = variant.manualSchema
+      ? createManualTypedFieldSchema(variant)
+      : createTypedFieldSchema(variant);
   }
 
   spec.components.schemas.FormalooFieldCreateRequest = {
@@ -1411,7 +1489,7 @@ function enrichFieldCreateSchemasAndOperations() {
       )
     },
     description:
-      "Generic field creation payload for documented, schema-backed field types. Use `type` to choose the field kind and `sub_type` when the field kind has variants. This schema reuses the same field-specific request schemas as the per-type field creation endpoints; dashboard-only shortcuts and special flows may require additional defaults not represented here."
+      "Generic field creation payload for documented form-editor field types. Use `type` to choose the field kind and `sub_type` when the field kind has variants. Most variants reuse the same field-specific request schemas as the per-type field creation endpoints. `table` and `email_verification` are documented here because the backend-generated OpenAPI currently exposes them as field-type enum values but does not generate dedicated request schemas for them."
   };
 
   const fieldsCreate = spec.paths["/v3.0/fields/"]?.post;
@@ -1419,7 +1497,7 @@ function enrichFieldCreateSchemasAndOperations() {
     upsertJsonRequestBody(fieldsCreate, "#/components/schemas/FormalooFieldCreateRequest", true);
     setOperationDescription(
       fieldsCreate,
-      "Recommended field creation endpoint for agents and form builders when adding documented, schema-backed field types through one URL. Prefer this endpoint when adding mixed field types programmatically; use `type` and, where needed, `sub_type` to select the exact field variant. The per-type endpoints document the same field-specific settings and remain available as specialized alternatives. Some dashboard editor shortcuts and special fields apply extra UI defaults or use contracts that are not yet fully represented in the generated OpenAPI schema."
+      "Recommended field creation endpoint for agents and form builders when adding documented form-editor field types through one URL. Prefer this endpoint when adding mixed field types programmatically; use `type` and, where needed, `sub_type` to select the exact field variant. The per-type endpoints document the same field-specific settings and remain available as specialized alternatives. Some dashboard editor shortcuts apply extra UI defaults, and `table` / `email_verification` are documented through the generic field-create schema because the generated backend OpenAPI does not currently expose dedicated request schemas for them."
     );
     setJsonExamples(fieldsCreate, {
       short_text: {
@@ -1473,6 +1551,31 @@ function enrichFieldCreateSchemasAndOperations() {
           choice_items: [{ title: "Speed" }, { title: "Price" }, { title: "Support" }]
         }
       },
+      table: {
+        summary: "Table field",
+        value: {
+          form: "customer-feedback",
+          title: "Order items",
+          type: "table"
+        }
+      },
+      email_verification: {
+        summary: "Email verification field",
+        value: {
+          form: "customer-feedback",
+          title: "Verify your email",
+          type: "email_verification"
+        }
+      },
+      ai_analysis: {
+        summary: "AI Analysis field",
+        value: {
+          form: "customer-feedback",
+          title: "Summarize this response",
+          type: "ai_box",
+          admin_only: true
+        }
+      },
       page_break: {
         summary: "Page break",
         value: {
@@ -1480,6 +1583,16 @@ function enrichFieldCreateSchemasAndOperations() {
           title: "Next section",
           type: "meta",
           sub_type: "page_break"
+        }
+      },
+      review: {
+        summary: "Review answers field",
+        value: {
+          form: "customer-feedback",
+          title: "Review",
+          type: "meta",
+          sub_type: "section",
+          description: "Review your answers before submitting:\n\n@review"
         }
       },
       variable: {

--- a/spec/docs/v3.0/fields/post.md
+++ b/spec/docs/v3.0/fields/post.md
@@ -1,29 +1,66 @@
-Creates a form field using the `type` supplied in the request body. This is the recommended endpoint for agents, CLI clients, and form builders that programmatically add documented, schema-backed field types through one URL.
+Creates a form field using the `type` supplied in the request body. This is the recommended endpoint for agents, CLI clients, and form builders that programmatically add fields through one URL.
 
 Use the `type` field to choose the field kind, and use `sub_type` only for field families that have variants.
 
-Common examples:
+Field types available from the dashboard form editor:
 
-| Field | `type` | `sub_type` |
-| --- | --- | --- |
-| Short text | `short_text` | — |
-| Long text | `long_text` | — |
-| Single choice | `choice` | — |
-| Dropdown | `dropdown` | — |
-| Multiple choice | `multiple_select` | `standard` |
-| Multiple choice dropdown | `multiple_select` | `dropdown` |
-| Ranking | `multiple_select` | `ranking` |
-| Star Rating / CSAT | `rating` | `embeded` |
-| Like/Dislike | `rating` | `like_dislike` |
-| NPS | `rating` | `nps` |
-| Slider | `rating` | `score` |
-| Page break | `meta` | `page_break` |
-| Section/content | `meta` | `section` |
-| Video content | `meta` | `video` |
-| Variable | `variable` | `int`, `decimal`, `string`, or `formula` |
+| Editor field | `type` | `sub_type` | Notes |
+| --- | --- | --- | --- |
+| Short Text | `short_text` | — | Single-line text answer. |
+| Long Text | `long_text` | — | Multi-line text answer. |
+| Email | `email` | — | Email-address answer. |
+| Phone Number | `phone` | — | Phone-number answer. |
+| Number | `number` | — | Numeric answer; use numeric constraint fields when needed. |
+| Website | `website` | — | URL answer. |
+| Checkbox | `checkbox` | — | Boolean checkbox. |
+| Single Choice | `choice` | — | Provide options with `choice_items` or `bulk_choices`. |
+| Dropdown | `dropdown` | — | Single-select dropdown; provide options with `choice_items` or `bulk_choices`. |
+| Multiple Choice | `multiple_select` | `standard` | Provide options with `choice_items` or `bulk_choices`. |
+| Multiple choice dropdown | `multiple_select` | `dropdown` | Multiple-select dropdown. |
+| Ranking | `multiple_select` | `ranking` | Respondents rank the provided options. |
+| Yes/No | `yes_no` | — | Binary yes/no field. |
+| Like/Dislike | `rating` | `like_dislike` | Thumbs up/down rating. |
+| Star Rating / CSAT | `rating` | `embeded` | Dashboard-compatible CSAT/star rating. |
+| Score / NPS | `rating` | `nps` | 0–10 NPS-style score. |
+| Slider | `rating` | `score` | Slider-style score. |
+| Matrix | `matrix` | — | Grid question; use `choice_groups` for rows and `choice_items` for columns/options. |
+| Date | `date` | — | Date answer. |
+| Time | `time` | — | Time answer. |
+| Date Time | `datetime` | — | Date-time answer. |
+| File Upload | `file` | — | Upload field; does not accept a `default` value. |
+| Content | `meta` | `section` | Static rich text/content block. |
+| Embed Video | `meta` | `video` | Video content block. |
+| New Page | `meta` | `page_break` | Page break; not used in one-question-at-a-time forms. |
+| Table | `table` | — | Collects multiple rows at once. |
+| Product | `product` | — | Product/payment field. |
+| Signature | `signature` | — | E-signature field. |
+| Repeating section | `repeating_section` | — | Repeating group of fields. |
+| Hidden Field | `hidden` | — | Hidden field for values not shown to submitters. |
+| AI Analysis | `ai_box` | — | Dashboard-created AI Analysis fields are `admin_only: true`. |
+| City | `city` | — | City selector. |
+| Country | `country` | — | Country selector. |
+| Lookup | `lookup` | — | Looks up values from a related source. |
+| Linked to another record | `linked_rows` | — | Links this form to records in another form. |
+| User Profile | `profile` | — | Connects a portal/user profile to form rows. |
+| Assignee | `assignee` | — | Assigns a user to a form row. |
+| Email verification | `email_verification` | — | Verifies the submitter's email with OTP. |
+| Custom Validation | `regex` | — | Text field with custom RegEx validation settings. |
+| Embed | `oembed` | — | Embeds external content such as PDFs, maps, or other oEmbed-compatible content. |
+| Variable | `variable` | `int` | Visible editor entry for logic/calculation variables. Other supported variable subtypes are `decimal`, `string`, and `formula`. |
 
 `embeded` is the legacy API spelling used for dashboard-compatible Star Rating / CSAT fields. Some generated contracts may also show `star`; prefer `embeded` for new fields that should edit cleanly in the dashboard.
 
 For choice-like fields, provide choices with either `choice_items` or `bulk_choices`, but not both. See the per-type field endpoints for the field-specific settings reused by this generic endpoint.
 
-Some dashboard editor items are shortcuts or special flows rather than distinct simple field contracts. For example, Contact Info creates multiple normal fields, Terms and Conditions and Review apply generated defaults, and some special fields may require additional contracts that are not yet fully represented in the generated OpenAPI schema.
+Dashboard editor shortcuts and special recipes:
+
+| Editor item | Recommended API behavior |
+| --- | --- |
+| Contact Info | Create four normal fields in order: `short_text` titled "First name", `short_text` titled "Last name", `email` titled "Email address", and `phone` titled "Phone number". The dashboard then sets each field's `theme_config.field_width` to one-half width. |
+| Terms and Conditions | Create a `multiple_select` field titled "Accept terms and conditions" with one choice titled "I Agree.", `max_selectable_choices: 1`, and a description containing the terms/privacy text or link. |
+| Section Divider | Create a `meta` + `section` field with static divider content in `description`. |
+| Review | Create a `meta` + `section` field with `description: "Review your answers before submitting:\n\n@review"`. |
+| Workspace Status | Create a workspace-level `choice` field with `isWorkspaceLevel: true` and `alias` set to the workspace status alias supplied by the client/workspace context. |
+| Workspace Due Date | Create a workspace-level `datetime` field with `isWorkspaceLevel: true` and `alias` set to the workspace due-date alias supplied by the client/workspace context. |
+
+Some field types, including `table` and `email_verification`, are present in the backend field-type enum and dashboard editor but do not currently have dedicated generated request schemas. Use the generic create endpoint with the documented `type` value and common field properties (`form`, `title`, `description`, `required`, etc.) unless backend-specific configuration is required.


### PR DESCRIPTION
## Summary

- document every visible dashboard form-editor field type in the generic `POST /v3.0/fields/` docs
- add generic OpenAPI create schemas for `table` and `email_verification`, which exist in the backend enum and dashboard editor but do not have generated request schemas
- document dashboard editor shortcut recipes such as Contact Info, Terms and Conditions, Section Divider, Review, and workspace-level fields

## Validation

- `./generate.sh`
- confirmed `FormalooFieldCreateRequest` maps all editor-visible field types, including `table` and `email_verification`
- public and MCP validation summaries report no errors or warnings
