### PR TITLE
feat(openapi): exclude legacy put operations from agent spec

### DIFF
--- a/scripts/build-mcp-openapi.mjs
+++ b/scripts/build-mcp-openapi.mjs
@@ -15,7 +15,7 @@ function asStringArray(value) {
   }
 
   return value
-    .map((item) => item.trim())
+    .map((item) => String(item ?? "").trim())
     .filter(Boolean);
 }
 
@@ -157,6 +157,14 @@ const excludedTagTokens = new Set(asStringArray(excludeSettings.tags).map(normal
 const excludedPathPrefixes = asStringArray(excludeSettings.pathPrefixes).map(preparePathRule);
 const excludedPathPatterns = asStringArray(excludeSettings.pathPatterns).map(prepareWildcardRule);
 const excludedEndpoints = new Set(asStringArray(excludeSettings.endpoints).map((endpoint) => normalizePathForCompare(endpoint)));
+const excludedHttpMethods = new Set(asStringArray(excludeSettings.httpMethods).map((method) => method.toLowerCase()));
+const approvedExcludedPutOperationIds = new Set(asStringArray(settings.approvedExcludedPutOperationIds));
+const methodExceptions = new Map(
+  Object.entries(settings.methodExceptions ?? {}).map(([method, operationIds]) => [
+    method.toLowerCase(),
+    new Set(asStringArray(operationIds))
+  ])
+);
 const excludedServiceIndex = await loadServiceExclusionIndex(excludedServices);
 
 const spec = JSON.parse(await fs.readFile(normalizedSpecPath, "utf8"));
@@ -256,6 +264,63 @@ function shouldExcludeEndpoint(pathKey) {
 
 function shouldExcludePath(pathKey) {
   return shouldExcludeByPathPrefix(pathKey) || shouldExcludeByWildcard(pathKey) || shouldExcludeEndpoint(pathKey);
+}
+
+function getOperationId(operation) {
+  const operationId = operation?.operationId;
+  return typeof operationId === "string" && operationId.trim().length > 0 ? operationId : null;
+}
+
+function isMethodException(method, operation) {
+  const operationId = getOperationId(operation);
+  return operationId !== null && methodExceptions.get(method.toLowerCase())?.has(operationId) === true;
+}
+
+function shouldExcludeByHttpMethod(method, operation) {
+  const methodToken = method.toLowerCase();
+  return excludedHttpMethods.has(methodToken) && !isMethodException(methodToken, operation);
+}
+
+const unsupportedSettingsErrors = [];
+if (settings.approvedExcludedPutOperationIds !== undefined && !Array.isArray(settings.approvedExcludedPutOperationIds)) {
+  unsupportedSettingsErrors.push("approvedExcludedPutOperationIds must be an array.");
+}
+
+if (
+  settings.methodExceptions !== undefined &&
+  (!settings.methodExceptions || typeof settings.methodExceptions !== "object" || Array.isArray(settings.methodExceptions))
+) {
+  unsupportedSettingsErrors.push("methodExceptions must be an object keyed by HTTP method.");
+}
+
+for (const [method, operationIds] of Object.entries(settings.methodExceptions ?? {})) {
+  if (!Array.isArray(operationIds)) {
+    unsupportedSettingsErrors.push(`methodExceptions.${method} must be an array.`);
+  }
+}
+
+if (excludedHttpMethods.has("put")) {
+  for (const [method, operationIds] of methodExceptions.entries()) {
+    if (method !== "put") {
+      unsupportedSettingsErrors.push(`methodExceptions.${method} is not supported for the MCP artifact.`);
+    }
+
+    for (const operationId of operationIds) {
+      if (method === "put" && operationId !== "paymentMethodsUpdate") {
+        unsupportedSettingsErrors.push(`Only paymentMethodsUpdate may be retained as a PUT exception, found ${operationId}.`);
+      }
+
+      if (approvedExcludedPutOperationIds.has(operationId)) {
+        unsupportedSettingsErrors.push(
+          `${operationId} cannot be both retained in methodExceptions.${method} and dropped by approvedExcludedPutOperationIds.`
+        );
+      }
+    }
+  }
+}
+
+if (unsupportedSettingsErrors.length > 0) {
+  throw new Error(`Invalid MCP OpenAPI settings:\n- ${unsupportedSettingsErrors.join("\n- ")}`);
 }
 
 function getRefTarget(openapiSpec, ref) {
@@ -1468,6 +1533,20 @@ function enrichMcpOperations(openapiSpec) {
         operation.summary = descriptionFix.summary;
         operation.description = descriptionFix.description;
       }
+
+      if (method === "put" && operation.operationId === "paymentMethodsUpdate") {
+        operation.description = [
+          operation.description,
+          "Temporary legacy PUT exception for payment method updates. Use this operation only until a PATCH replacement is available; do not model it as a partial update."
+        ]
+          .filter((part) => typeof part === "string" && part.trim().length > 0)
+          .join("\n\n");
+        operation["x-formaloo-legacy-put"] = {
+          legacy_put_exception: true,
+          temporary: true,
+          replacement_policy: "Remove this PUT exception when a PATCH payment method update operation is available."
+        };
+      }
     }
   }
 }
@@ -1475,6 +1554,12 @@ function enrichMcpOperations(openapiSpec) {
 const filteredPaths = {};
 const usedTagNames = new Set();
 let removedOperations = 0;
+const observedMcpScopedPutOperationIds = new Set();
+const retainedPutOperationIds = new Set();
+const droppedApprovedPutOperationIds = new Set();
+const unknownPutOperations = [];
+const retainedPutRecords = new Map();
+const mcpScopedPatchRecords = [];
 
 for (const [pathKey, pathItem] of Object.entries(spec.paths ?? {})) {
   if (!pathItem || typeof pathItem !== "object") {
@@ -1490,7 +1575,35 @@ for (const [pathKey, pathItem] of Object.entries(spec.paths ?? {})) {
       continue;
     }
 
-    if (pathExcluded || shouldExcludeByService(pathKey, method, operation) || operationHasExcludedTag(operation)) {
+    const methodToken = method.toLowerCase();
+    const excludedByMcpScope =
+      pathExcluded || shouldExcludeByService(pathKey, method, operation) || operationHasExcludedTag(operation);
+    const operationId = getOperationId(operation);
+
+    if (methodToken === "patch" && !excludedByMcpScope) {
+      mcpScopedPatchRecords.push({ operationId, pathKey });
+    }
+
+    if (methodToken === "put" && !excludedByMcpScope) {
+      if (operationId !== null) {
+        observedMcpScopedPutOperationIds.add(operationId);
+      }
+
+      if (isMethodException(methodToken, operation)) {
+        retainedPutOperationIds.add(operationId);
+        retainedPutRecords.set(operationId, { pathKey, operation });
+      } else if (operationId !== null && approvedExcludedPutOperationIds.has(operationId)) {
+        droppedApprovedPutOperationIds.add(operationId);
+        removedOperations += 1;
+        continue;
+      } else {
+        unknownPutOperations.push(`${operationId ?? "<missing operationId>"} PUT ${pathKey}`);
+        removedOperations += 1;
+        continue;
+      }
+    }
+
+    if (shouldExcludeByHttpMethod(method, operation) || excludedByMcpScope) {
       removedOperations += 1;
       continue;
     }
@@ -1507,6 +1620,42 @@ for (const [pathKey, pathItem] of Object.entries(spec.paths ?? {})) {
   }
 }
 
+const putGateErrors = [];
+const staleApprovedPutOperationIds = [];
+for (const operationId of approvedExcludedPutOperationIds) {
+  if (!observedMcpScopedPutOperationIds.has(operationId)) {
+    staleApprovedPutOperationIds.push(operationId);
+  }
+}
+
+for (const operationId of methodExceptions.get("put") ?? []) {
+  if (!retainedPutOperationIds.has(operationId)) {
+    putGateErrors.push(`${operationId} is configured as a retained PUT exception but was not found in the MCP-scoped upstream spec.`);
+  }
+}
+
+if (unknownPutOperations.length > 0) {
+  putGateErrors.push(
+    `Unknown MCP-scoped PUT operation(s) require review before exclusion or retention: ${unknownPutOperations.join(", ")}.`
+  );
+}
+
+const retainedPaymentPut = retainedPutRecords.get("paymentMethodsUpdate");
+if (methodExceptions.get("put")?.has("paymentMethodsUpdate") === true && retainedPaymentPut) {
+  const paymentPatchCounterpart = mcpScopedPatchRecords.find(
+    (record) => record.operationId === "paymentMethodsPartialUpdate" || record.pathKey === retainedPaymentPut.pathKey
+  );
+  if (paymentPatchCounterpart) {
+    putGateErrors.push(
+      `paymentMethodsUpdate is still retained as a legacy PUT exception, but PATCH ${paymentPatchCounterpart.pathKey} is available. Remove the PUT exception and use PATCH.`
+    );
+  }
+}
+
+if (putGateErrors.length > 0) {
+  throw new Error(`MCP PUT review gate failed:\n- ${putGateErrors.join("\n- ")}`);
+}
+
 spec.paths = filteredPaths;
 spec.tags = (spec.tags ?? []).filter((tag) => typeof tag?.name === "string" && usedTagNames.has(tag.name));
 relaxWorkspaceHeaderRequirements(spec);
@@ -1520,6 +1669,11 @@ console.log(`MCP filtered spec -> ${path.relative(rootDir, mcpSpecPath)}`);
 console.log(`MCP settings file -> ${path.relative(rootDir, settingsPath)}`);
 if (excludedServiceIndex.missingServices.length > 0) {
   console.log(`Unknown services in settings: ${excludedServiceIndex.missingServices.join(", ")}`);
+}
+if (staleApprovedPutOperationIds.length > 0) {
+  console.log(
+    `Stale approved PUT exclusions not present in current MCP scope: ${staleApprovedPutOperationIds.sort().join(", ")}`
+  );
 }
 console.log(`Removed operations: ${removedOperations}`);
 console.log(`Remaining paths: ${Object.keys(spec.paths ?? {}).length}`);

--- a/scripts/validate-mcp-openapi.mjs
+++ b/scripts/validate-mcp-openapi.mjs
@@ -5,6 +5,7 @@ const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), ".
 const artifactsDir = path.join(rootDir, "artifacts");
 const validationDir = path.join(artifactsDir, "validation");
 const defaultSpecPath = path.join(artifactsDir, "intermediate", "openapi-mcp.filtered.json");
+const settingsPath = path.join(rootDir, "spec", "mcp-openapi-settings.json");
 const specPathInput = process.argv[2] ?? defaultSpecPath;
 const specPath = path.isAbsolute(specPathInput) ? specPathInput : path.join(rootDir, specPathInput);
 
@@ -39,11 +40,44 @@ const requiredMcpReadyOperationIds = [
   "themesRetrieve",
   "themesPartialUpdate"
 ];
+const requiredPatchUpdateOperationIds = [
+  "fieldsPartialUpdate",
+  "formsPartialUpdate",
+  "formFieldsPartialUpdate",
+  "themesPartialUpdate"
+];
+const removedPutMigrationTargets = {
+  fieldsUpdate: "fieldsPartialUpdate",
+  formFieldsUpdate: "formFieldsPartialUpdate",
+  formsUpdate: "formsPartialUpdate",
+  paymentMethodsUpdate: "paymentMethodsPartialUpdate",
+  themesUpdate: "themesPartialUpdate"
+};
 
+const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
 const spec = JSON.parse(await fs.readFile(specPath, "utf8"));
 const errors = [];
 const warnings = [];
 const operations = new Map();
+const excludeSettings = settings.exclude ?? {};
+const excludedHttpMethods = new Set(asStringArray(excludeSettings.httpMethods).map((method) => method.toLowerCase()));
+const approvedExcludedPutOperationIds = new Set(asStringArray(settings.approvedExcludedPutOperationIds));
+const methodExceptions = new Map(
+  Object.entries(settings.methodExceptions ?? {}).map(([method, operationIds]) => [
+    method.toLowerCase(),
+    new Set(asStringArray(operationIds))
+  ])
+);
+
+function asStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean);
+}
 
 function hasText(value) {
   return typeof value === "string" && value.trim().length > 0;
@@ -167,6 +201,11 @@ for (const operationId of requiredMcpReadyOperationIds) {
   validateRequiredOperation(operationId, "Required MCP-ready operation");
 }
 
+validateMethodExclusions();
+validatePutSettings();
+validatePatchFirstUpdates();
+validatePaymentMethodPutException();
+
 function validateRequiredOperation(operationId, label) {
   const record = operations.get(operationId);
   if (!record) {
@@ -196,6 +235,150 @@ function validateRequiredOperation(operationId, label) {
   }
 
   validateMcpMetadata(operationId, operation);
+}
+
+function validateMethodExclusions() {
+  for (const [operationId, { method, pathKey }] of operations.entries()) {
+    const methodToken = method.toLowerCase();
+    if (!excludedHttpMethods.has(methodToken)) {
+      continue;
+    }
+
+    const allowedOperationIds = methodExceptions.get(methodToken) ?? new Set();
+    if (!allowedOperationIds.has(operationId)) {
+      errors.push(
+        `${operationId} ${method.toUpperCase()} ${pathKey} uses excluded HTTP method ${method.toUpperCase()}. Add an explicit reviewed exception or remove it from the MCP spec.`
+      );
+    }
+  }
+
+  for (const [method, operationIds] of methodExceptions.entries()) {
+    if (!excludedHttpMethods.has(method)) {
+      errors.push(`methodExceptions.${method} is configured but ${method.toUpperCase()} is not excluded.`);
+    }
+
+    for (const operationId of operationIds) {
+      const record = operations.get(operationId);
+      if (!record) {
+        errors.push(`methodExceptions.${method} includes ${operationId}, but that operation is not present in the MCP spec.`);
+        continue;
+      }
+
+      if (record.method !== method) {
+        errors.push(
+          `methodExceptions.${method} includes ${operationId}, but the operation method is ${record.method.toUpperCase()}.`
+        );
+      }
+    }
+  }
+}
+
+function validatePutSettings() {
+  if (!Array.isArray(settings.approvedExcludedPutOperationIds)) {
+    errors.push("approvedExcludedPutOperationIds must be an array.");
+  }
+
+  if (
+    settings.methodExceptions !== undefined &&
+    (!settings.methodExceptions || typeof settings.methodExceptions !== "object" || Array.isArray(settings.methodExceptions))
+  ) {
+    errors.push("methodExceptions must be an object keyed by HTTP method.");
+  }
+
+  for (const [method, operationIds] of Object.entries(settings.methodExceptions ?? {})) {
+    if (!Array.isArray(operationIds)) {
+      errors.push(`methodExceptions.${method} must be an array.`);
+    }
+  }
+
+  if (approvedExcludedPutOperationIds.has("paymentMethodsUpdate")) {
+    errors.push("paymentMethodsUpdate must be retained through methodExceptions.put, not approvedExcludedPutOperationIds.");
+  }
+
+  for (const method of methodExceptions.keys()) {
+    if (method !== "put") {
+      errors.push(`methodExceptions.${method} is not supported for the MCP artifact.`);
+    }
+  }
+
+  const putExceptions = methodExceptions.get("put") ?? new Set();
+  for (const operationId of putExceptions) {
+    if (operationId !== "paymentMethodsUpdate") {
+      errors.push(`Only paymentMethodsUpdate may be retained as a PUT exception, found ${operationId}.`);
+    }
+
+    if (approvedExcludedPutOperationIds.has(operationId)) {
+      errors.push(`${operationId} cannot be both retained and approved for PUT exclusion.`);
+    }
+  }
+}
+
+function validatePatchFirstUpdates() {
+  for (const operationId of requiredPatchUpdateOperationIds) {
+    const record = operations.get(operationId);
+    if (!record) {
+      errors.push(`Required PATCH update operation ${operationId} is not present.`);
+      continue;
+    }
+
+    if (record.method !== "patch") {
+      errors.push(`Required update operation ${operationId} must use PATCH, found ${record.method.toUpperCase()}.`);
+    }
+  }
+
+  for (const [operationId, patchCounterpart] of Object.entries(removedPutMigrationTargets)) {
+    const record = operations.get(operationId);
+    if (record?.method === "put" && operationId !== "paymentMethodsUpdate") {
+      errors.push(`${operationId} was removed from the MCP spec; use PATCH operation ${patchCounterpart} instead.`);
+    }
+  }
+}
+
+function validatePaymentMethodPutException() {
+  const allowedPutExceptions = methodExceptions.get("put") ?? new Set();
+  const actualPutOperations = [...operations.entries()].filter(([, record]) => record.method === "put");
+  const unexpectedConfiguredExceptions = [...allowedPutExceptions].filter((operationId) => operationId !== "paymentMethodsUpdate");
+
+  if (unexpectedConfiguredExceptions.length > 0) {
+    errors.push(`Only paymentMethodsUpdate may be allowlisted as a PUT exception, found: ${unexpectedConfiguredExceptions.join(", ")}.`);
+  }
+
+  for (const [operationId, { pathKey }] of actualPutOperations) {
+    if (operationId !== "paymentMethodsUpdate") {
+      errors.push(`${operationId} PUT ${pathKey} is not allowed in the MCP spec; use PATCH when available.`);
+    }
+  }
+
+  const paymentPut = operations.get("paymentMethodsUpdate");
+  if (allowedPutExceptions.has("paymentMethodsUpdate")) {
+    if (!paymentPut) {
+      errors.push("paymentMethodsUpdate is allowlisted as a PUT exception, but it is not present in the MCP spec.");
+      return;
+    }
+
+    if (paymentPut.method !== "put") {
+      errors.push(`paymentMethodsUpdate must remain PUT while allowlisted, found ${paymentPut.method.toUpperCase()}.`);
+    }
+
+    if (!paymentPut.operation.description?.includes("Temporary legacy PUT exception")) {
+      errors.push("paymentMethodsUpdate must be described as a temporary legacy PUT exception.");
+    }
+
+    const metadata = paymentPut.operation["x-formaloo-legacy-put"];
+    if (metadata?.legacy_put_exception !== true || metadata?.temporary !== true) {
+      errors.push("paymentMethodsUpdate x-formaloo-legacy-put metadata must mark it as a temporary legacy PUT exception.");
+    }
+  }
+
+  const paymentPatch = operations.get("paymentMethodsPartialUpdate");
+  const paymentPatchOnSamePath =
+    paymentPut &&
+    [...operations.values()].some((record) => record.method === "patch" && record.pathKey === paymentPut.pathKey);
+  if (allowedPutExceptions.has("paymentMethodsUpdate") && (paymentPatch?.method === "patch" || paymentPatchOnSamePath)) {
+    errors.push(
+      "paymentMethodsUpdate is still allowlisted as a PUT exception, but a PATCH payment method update operation is available. Remove the PUT exception and use PATCH."
+    );
+  }
 }
 
 for (const [operationId, { operation, method, pathKey }] of operations.entries()) {

--- a/spec/mcp-openapi-settings.json
+++ b/spec/mcp-openapi-settings.json
@@ -1,5 +1,8 @@
 {
   "exclude": {
+    "httpMethods": [
+      "put"
+    ],
     "services": [
       "authentication",
       "ai"
@@ -49,6 +52,41 @@
       "/profiles/{type}/request-login/",
       "/prompt-categories/{tagSlug}/examples/",
       "/usage/"
+    ]
+  },
+  "approvedExcludedPutOperationIds": [
+    "boardsBlocksItemsUpdate",
+    "boardsBlocksUpdate",
+    "boardsUpdate",
+    "anonymizationConfigsUpdate",
+    "businessEnginesUpdate",
+    "businessesMembersUpdate",
+    "businessesTeamsUpdate",
+    "businessesUpdate",
+    "campaignsUpdate",
+    "draftRowsUpdate",
+    "emailServersUpdate",
+    "emailTemplatesUpdate",
+    "fieldsUpdate",
+    "foldersUpdate",
+    "formFieldsUpdate",
+    "formsUpdate",
+    "formsWebhooksUpdate",
+    "pdfTemplatesUpdate",
+    "recurringSubmissionsUpdate",
+    "profileUpdate",
+    "rowsUpdate",
+    "sharedBoardsBlocksRowsUpdate",
+    "sharedBoardsProfileUpdate",
+    "tagsUpdate",
+    "themesUpdate",
+    "userFormRowsUpdate",
+    "userFormsSsoConfigUpdate",
+    "userFormsUpdate"
+  ],
+  "methodExceptions": {
+    "put": [
+      "paymentMethodsUpdate"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- exclude PUT operations before MCP enrichment and schema pruning
- retain only the temporary paymentMethodsUpdate exception
- fail validation for unknown PUTs or when a PATCH replacement makes the exception obsolete
- mark the retained payment update as a legacy full-replacement operation

## Validation
- ./generate.sh
- generated agent artifact contains exactly one PUT: paymentMethodsUpdate
- public and MCP OpenAPI validation pass (existing askCustomDomainRetrieve description warning remains)